### PR TITLE
ci: cut releases from a tag, publish to npm without a stored token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+# Cutting a release is `git tag v0.2.0 && git push origin v0.2.0`. Nothing
+# publishes on a branch push — only a v* tag reaches this workflow.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write # create the GitHub release
+  id-token: write # mint the OIDC token npm trusted publishing exchanges for a credential
+
+jobs:
+  release:
+    name: publish @edeng23/pines
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # --generate-notes diffs against the previous tag, which needs more
+          # than the shallow single commit checkout gives us by default.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing needs npm >= 11.5.1. Node 22 still bundles npm 10.x,
+      # which has no idea what an OIDC exchange is and falls back to asking for
+      # a token that does not exist here.
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      # A tag that disagrees with package.json ships the wrong version number,
+      # and npm burns a version forever — it can never be republished, even
+      # after an unpublish. Cheaper to fail here than to skip to 0.1.1.
+      - name: Assert tag matches package.json version
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "tag ${GITHUB_REF_NAME} implies version ${tag}, package.json says ${pkg}"
+            exit 1
+          fi
+          echo "releasing ${pkg}"
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm typecheck
+      - run: pnpm test
+
+      # Same guard as CI's `package` job. It runs again here because CI green on
+      # a branch does not prove the tagged tree still packs correctly, and a
+      # tarball missing schema.sql dies in openDb before the daemon ever binds.
+      - name: Assert runtime assets survived packing
+        run: |
+          set -euo pipefail
+          tarball="$(pwd)/$(npm pack --silent)"
+          contents="$(tar -tzf "$tarball")"
+          for required in \
+            package/dist/cli.js \
+            package/src/store/schema.sql \
+            package/src/extension/pines-extension.ts
+          do
+            echo "$contents" | grep -qx "$required" \
+              || { echo "MISSING from tarball: $required"; exit 1; }
+          done
+          echo "all runtime assets present"
+
+      # --ignore-scripts skips prepublishOnly, whose typecheck+test we just ran
+      # explicitly above. Running that suite twice only doubles the exposure to
+      # the flaky timing tests; it proves nothing new. No prepack/prepare exist,
+      # so nothing else is being skipped.
+      # --provenance is explicit: relying on npm to infer it from CI has been
+      # unreliable in practice.
+      - name: Publish to npm
+        run: npm publish --provenance --access public --ignore-scripts
+
+      # After the publish, so a failed publish does not strand a GitHub release
+      # pointing at a version nobody can install.
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,55 @@
+# Releasing
+
+Releases are cut by pushing a tag. `.github/workflows/release.yml` does the rest:
+it verifies the tag against `package.json`, builds, runs the suite, re-checks the
+tarball, publishes to npm with provenance, and opens the GitHub release.
+
+```sh
+# bump "version" in package.json first, and commit it
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+Nothing publishes on a branch push. Only a `v*` tag triggers the workflow.
+
+## One-time bootstrap
+
+The workflow authenticates to npm with OIDC trusted publishing, which means no
+`NPM_TOKEN` secret lives in the repo. It has one catch: **OIDC cannot perform a
+package's first publish.** npm only lets you attach a trusted publisher to a
+package that already exists, and the package cannot exist until something
+publishes it. npm/cli#8544 tracks this; PyPI allows pre-registering a publisher
+for a package that does not exist yet, npm does not.
+
+So the first release is manual, once, from a machine:
+
+1. `npm login`
+2. `pnpm install && pnpm build`
+3. `npm publish --access public`
+   (`--access public` matters: scoped packages default to restricted, which
+   would publish it private and fail for everyone running `npx @edeng23/pines`.)
+
+Then attach the trusted publisher so every later release is automated:
+
+4. Go to `https://www.npmjs.com/package/@edeng23/pines/access`
+5. Under **Trusted Publisher**, choose GitHub Actions and enter:
+   - Organization or user: `edeng23`
+   - Repository: `pines`
+   - Workflow filename: `release.yml`
+   - Environment: leave blank
+6. Tag `v0.1.0` and push it, to confirm the automated path works end to end.
+
+After step 5, no npm credential is needed on any machine or in any secret.
+
+## Notes
+
+- npm never lets a version number be reused, even after an unpublish, and the
+  unpublish window is only 72 hours. The workflow's tag-vs-`package.json` check
+  exists because getting this wrong costs a version number permanently.
+- The publish step passes `--ignore-scripts` to skip `prepublishOnly`. Its
+  `typecheck` and `test` already ran as explicit steps in the same job; running
+  them twice only doubles exposure to the timing flakes in the daemon and
+  extension-status suites.
+- If a release fails *after* the npm publish but before the GitHub release, do
+  not retag. Create the GitHub release by hand:
+  `gh release create v0.2.0 --generate-notes`.


### PR DESCRIPTION
Pushing a `v*` tag now builds, verifies and publishes `@edeng23/pines`, then opens the GitHub release. Nothing publishes on a branch push.

## Why OIDC

Authentication is npm trusted publishing over OIDC, so no `NPM_TOKEN` sits in repo secrets waiting to leak, and the package gets signed provenance for free.

It costs one manual step. **OIDC cannot perform a package first publish** — npm only attaches a trusted publisher to a package that already exists, and the package cannot exist until something publishes it ([npm/cli#8544](https://github.com/npm/cli/issues/8544), still open). `docs/RELEASING.md` walks through the one-time bootstrap: `npm login`, publish `0.1.0` by hand with `--access public`, then attach the trusted publisher at `npmjs.com/package/@edeng23/pines/access`. Every release after that is fully automated.

This is worth knowing now: `@edeng23/pines` does not exist on the registry yet (`registry.npmjs.org` 404s it), while README lines 10 and 13 already tell people to run `npx @edeng23/pines`. That bootstrap publish is what makes the README true.

## Guards

- **Tag vs `package.json`**, checked before anything builds. npm burns a version number permanently — it can never be reused, even after an unpublish, and the unpublish window is 72h. A mismatched tag should cost a retry, not a version.
- **Tarball assertion** from CI `package` job, run again here. CI green on a branch does not prove the *tagged* tree still packs `schema.sql`, and a tarball missing it dies in `openDb` before the daemon binds its socket.
- `npm >= 11.5.1` is installed explicitly; Node 22 bundles npm 10.x, which cannot do the OIDC exchange.

## On `--ignore-scripts`

The publish step skips `prepublishOnly`, whose `typecheck` and `test` already ran as explicit steps in the same job. I confirmed no `prepack` or `prepare` scripts exist, so nothing else is skipped. Running the suite twice would only double exposure to the `ext-status.test.ts` timing flake that already turned `main` red once today.

## Verification

- YAML parses; trigger, permissions and all 12 steps confirmed
- Version guard tested both ways: accepts `v0.1.0` against `package.json` `0.1.0`, rejects `v0.9.9` with a nonzero exit
- Confirmed via `package.json` that `--ignore-scripts` skips only `prepublishOnly`

Not yet exercised end to end, because that requires the bootstrap publish above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)