### PR TITLE
ci: release on version-bump merges to main (no local tag needed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,18 @@
 name: Release
 
-# Cutting a release is `git tag v0.2.0 && git push origin v0.2.0`. Nothing
-# publishes on a branch push — only a v* tag reaches this workflow.
+# A release is a version bump reaching main. When package.json names a version
+# that has no matching v* tag yet, this workflow builds, tests, re-checks the
+# tarball, publishes to npm, and creates the tag + GitHub release itself —
+# merging the bump PR is the whole ceremony. Pushing a v* tag by hand still
+# works and takes the same guarded path. Ordinary merges (version unchanged)
+# no-op at the first step.
 on:
   push:
+    branches: [main]
     tags: ["v*"]
 
 permissions:
-  contents: write # create the GitHub release
+  contents: write # create the tag + GitHub release
   id-token: write # mint the OIDC token npm trusted publishing exchanges for a credential
 
 jobs:
@@ -18,8 +23,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # --generate-notes diffs against the previous tag, which needs more
-          # than the shallow single commit checkout gives us by default.
+          # than the shallow single commit checkout gives us by default; the
+          # tags are the "already released?" ledger the decide step reads.
           fetch-depth: 0
+          fetch-tags: true
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -29,37 +36,56 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      # A tag that disagrees with package.json ships the wrong version number,
+      # and npm burns a version forever — it can never be republished, even
+      # after an unpublish. On a main push there is nothing to disagree with:
+      # the version IS package.json's, and the guard becomes "was it already
+      # tagged?", which is what lets every non-bump merge land here for free.
+      - name: Decide whether this push is a release
+        id: decide
+        run: |
+          set -euo pipefail
+          pkg="$(node -p "require('./package.json').version")"
+          echo "version=${pkg}" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            tag="${GITHUB_REF_NAME#v}"
+            if [ "$tag" != "$pkg" ]; then
+              echo "tag ${GITHUB_REF_NAME} implies version ${tag}, package.json says ${pkg}"
+              exit 1
+            fi
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "releasing ${pkg} (tag push)"
+          elif git rev-parse -q --verify "refs/tags/v${pkg}" >/dev/null; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "v${pkg} is already tagged — nothing to release"
+          else
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "releasing ${pkg} (version bump reached main)"
+          fi
+
       # Trusted publishing needs npm >= 11.5.1. Node 22 still bundles npm 10.x,
       # which has no idea what an OIDC exchange is and falls back to asking for
       # a token that does not exist here.
       - name: Upgrade npm for trusted publishing
+        if: steps.decide.outputs.release == 'true'
         run: |
           npm install -g npm@latest
           npm --version
 
-      # A tag that disagrees with package.json ships the wrong version number,
-      # and npm burns a version forever — it can never be republished, even
-      # after an unpublish. Cheaper to fail here than to skip to 0.1.1.
-      - name: Assert tag matches package.json version
-        run: |
-          set -euo pipefail
-          tag="${GITHUB_REF_NAME#v}"
-          pkg="$(node -p "require('./package.json').version")"
-          if [ "$tag" != "$pkg" ]; then
-            echo "tag ${GITHUB_REF_NAME} implies version ${tag}, package.json says ${pkg}"
-            exit 1
-          fi
-          echo "releasing ${pkg}"
-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - run: pnpm typecheck
-      - run: pnpm test
+      - if: steps.decide.outputs.release == 'true'
+        run: pnpm install --frozen-lockfile
+      - if: steps.decide.outputs.release == 'true'
+        run: pnpm build
+      - if: steps.decide.outputs.release == 'true'
+        run: pnpm typecheck
+      - if: steps.decide.outputs.release == 'true'
+        run: pnpm test
 
       # Same guard as CI's `package` job. It runs again here because CI green on
-      # a branch does not prove the tagged tree still packs correctly, and a
+      # a branch does not prove the released tree still packs correctly, and a
       # tarball missing schema.sql dies in openDb before the daemon ever binds.
       - name: Assert runtime assets survived packing
+        if: steps.decide.outputs.release == 'true'
         run: |
           set -euo pipefail
           tarball="$(pwd)/$(npm pack --silent)"
@@ -80,15 +106,34 @@ jobs:
       # so nothing else is being skipped.
       # --provenance is explicit: relying on npm to infer it from CI has been
       # unreliable in practice.
+      # The "already published" check makes a re-run after a half-finished
+      # release repair the tag and GitHub release instead of dying on npm's
+      # "version already exists".
       - name: Publish to npm
-        run: npm publish --provenance --access public --ignore-scripts
+        if: steps.decide.outputs.release == 'true'
+        run: |
+          set -euo pipefail
+          v="${{ steps.decide.outputs.version }}"
+          if [ -n "$(npm view "@edeng23/pines@${v}" version 2>/dev/null)" ]; then
+            echo "npm already has ${v} — skipping publish"
+          else
+            npm publish --provenance --access public --ignore-scripts
+          fi
 
       # After the publish, so a failed publish does not strand a GitHub release
-      # pointing at a version nobody can install.
-      - name: Create GitHub release
+      # pointing at a version nobody can install. On a main push this is also
+      # what mints the v* tag: gh tags the pushed commit as part of creating
+      # the release. (Tags created with the workflow token do not trigger
+      # workflows, so the v* trigger above cannot recurse on it.)
+      - name: Create GitHub release (and tag)
+        if: steps.decide.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes
+          set -euo pipefail
+          v="v${{ steps.decide.outputs.version }}"
+          if gh release view "$v" >/dev/null 2>&1; then
+            echo "release $v already exists"
+          else
+            gh release create "$v" --target "$GITHUB_SHA" --title "$v" --generate-notes
+          fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,16 +1,19 @@
 # Releasing
 
-Releases are cut by pushing a tag. `.github/workflows/release.yml` does the rest:
-it verifies the tag against `package.json`, builds, runs the suite, re-checks the
-tarball, publishes to npm with provenance, and opens the GitHub release.
+Releases are cut by merging a version bump to `main`. When a push to `main`
+carries a `package.json` version that has no `v*` tag yet,
+`.github/workflows/release.yml` does the rest: builds, runs the suite,
+re-checks the tarball, publishes to npm with provenance, and creates the tag
+and GitHub release itself.
 
 ```sh
-# bump "version" in package.json first, and commit it
-git tag v0.2.0
-git push origin v0.2.0
+# on a branch: bump "version" in package.json, commit, open a PR, merge it.
+# that's the whole ceremony — the workflow tags and publishes on the merge.
 ```
 
-Nothing publishes on a branch push. Only a `v*` tag triggers the workflow.
+Merges that don't change the version no-op at the workflow's first step.
+Pushing a `v*` tag by hand still works too (same guarded path, and the tag
+must match `package.json`) — useful for releasing an older commit.
 
 ## One-time bootstrap
 
@@ -37,19 +40,21 @@ Then attach the trusted publisher so every later release is automated:
    - Repository: `pines`
    - Workflow filename: `release.yml`
    - Environment: leave blank
-6. Tag `v0.1.0` and push it, to confirm the automated path works end to end.
+6. Merge a version bump to `main`, to confirm the automated path end to end.
 
 After step 5, no npm credential is needed on any machine or in any secret.
 
 ## Notes
 
 - npm never lets a version number be reused, even after an unpublish, and the
-  unpublish window is only 72 hours. The workflow's tag-vs-`package.json` check
-  exists because getting this wrong costs a version number permanently.
+  unpublish window is only 72 hours. The workflow's guards (tag must match
+  `package.json`; an already-tagged version never re-releases) exist because
+  getting this wrong costs a version number permanently.
 - The publish step passes `--ignore-scripts` to skip `prepublishOnly`. Its
   `typecheck` and `test` already ran as explicit steps in the same job; running
   them twice only doubles exposure to the timing flakes in the daemon and
   extension-status suites.
-- If a release fails *after* the npm publish but before the GitHub release, do
-  not retag. Create the GitHub release by hand:
-  `gh release create v0.2.0 --generate-notes`.
+- If a release fails *after* the npm publish but before the GitHub release,
+  just re-run the workflow (or push any commit to `main`): the publish step
+  skips versions npm already has, and the release step then repairs the
+  missing tag + GitHub release idempotently.


### PR DESCRIPTION
Makes releasing fully part of the GitHub flow: when a push to `main` carries a `package.json` version that has no matching `v*` tag, `release.yml` builds, tests, re-checks the tarball, publishes to npm (trusted publishing, unchanged — it's keyed to the workflow filename), and then **creates the tag + GitHub release itself** via `gh release create --target`. Merging a version-bump PR is the whole release ceremony; nobody needs a local `git tag && git push` anymore.

Details:

- **Ordinary merges no-op** at the first step: if `v<package.json version>` is already tagged, the run ends immediately.
- **The manual `v*` tag path still works** and shares the same job, keeping the existing tag-vs-`package.json` mismatch guard — useful for releasing an older commit.
- **No recursion:** the tag is created with the workflow's `GITHUB_TOKEN`, and tags created by a workflow token don't trigger workflows.
- **Idempotent repair:** the publish step skips versions npm already has, and the release step skips existing releases — so a half-finished release (e.g. published to npm but died before tagging) is repaired by a re-run instead of dying on "version already exists".
- `docs/RELEASING.md` updated to describe the new ceremony.

⚠️ Heads-up on merge behavior, intentionally: `main` currently says `0.1.2` with no `v0.1.2` tag — so **merging this PR immediately releases 0.1.2** (npm publish + tag + GitHub release). That completes the release that's currently pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QuVLfbJnrCTPHCmyqsqTh

---
_Generated by [Claude Code](https://claude.ai/code/session_019QuVLfbJnrCTPHCmyqsqTh)_