### PR TITLE
v0.1.4: flow view, live working tip, chat-style branching from questions

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -118,7 +118,7 @@ and a first run — all placed by the same layout the daemon uses.
 | view | keys / mouse |
 |---|---|
 | forest | `↑`/`↓` move through the sidebar list · `Enter` attach · `→` open tree view · wheel = zoom at cursor · drag = pan · click = select · double-click = open (canvas) / attach (sidebar) · `hjkl` pan · `+`/`-` zoom · `0` fit · `Tab` cycle by attention · `o` jump to most urgent · `a` attach · `n` new tree and attach · `r`/`L` rename tree · `A`/`Ctrl+X` archive/unarchive · `.` show/hide archived · `S` sidebar · `[`/`]` sidebar width · `x` kill agent · `R` relayout · `s` similar conversations · `/` search · `?` help |
-| tree | `↑`/`↓` or `j`/`k` move · `→`/`Enter` — on a tip (a node showing an agent's status): attach to that branch's agent (resume if dormant); on a `⋯` row: expand; on a `[+]` row: unfold; on any other message: grow a new branch there with its own agent and attach · `1`-`9` jump to a branch tip · `←`/`Esc` back to the forest · `b` branch menu (with/without agent) · `L` label · `r` rename tree · `/` search |
+| tree | `↑`/`↓` or `j`/`k` move · `→`/`Enter` — on a tip (a node showing an agent's status): attach to that branch's agent (resume if dormant); on a `⋯` row: expand; on a `[+]` row: unfold; on any other message: grow a new branch there with its own agent and attach (from a question: *beside* it — the question stays out) · `f` flow (one branch's conversation) ⇄ full tree · `1`-`9` jump to a branch tip · `←`/`Esc` back to the forest · `b` branch menu (with/without agent) · `L` label · `r` rename tree · `/` search |
 | attached pi | everything goes to pi, except the prefix `Ctrl+t`: `←`/`d` = back to tree · `f` = forest · `n` = next attention target · `Ctrl+t Ctrl+t` = send a literal Ctrl+t |
 
 Zooming is semantic: the sprite is the tree at every distance — maturity by
@@ -157,9 +157,21 @@ background-only launch.
 
 **Branching** (`b` on any message, or just `Enter` on a non-tip message):
 grows a new branch of the same tree, optionally with an agent on it.
-Branches never touch each other's agents, so branching while one works is
-always possible — that is the multiplexing model. (In-place leaf moves
-still exist in the daemon for pi's own navigation.)
+Where the fork lands depends on what you point at: a *reply* branches after
+its exchange; a *question* branches from just before it — the question is
+not part of the new branch, so your next message replaces it as a sibling
+(the way editing a message works in chat UIs) and the old answer can never
+read as answering the new question. The `b` menu's *re-answer* keeps the
+question and regenerates only the answer. Branches never touch each other's
+agents, so branching while one works is always possible — that is the
+multiplexing model. (In-place leaf moves still exist in the daemon for pi's
+own navigation.)
+
+**Flow view** (`f`): narrows the transcript to one branch's conversation —
+the cursor's — root to tip, nothing else. The metro map keeps the whole
+shape with that route drawn bold, and the agents panel keeps every branch:
+jumping to another agent (`1`-`9`, click) switches the flow to it. `f`
+again restores the full tree.
 
 **Search** (`/`): SQLite FTS5 over session names, every user message (abandoned
 branches included), compaction/branch summaries, and labels. `Enter` jumps to

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -118,7 +118,7 @@ and a first run — all placed by the same layout the daemon uses.
 | view | keys / mouse |
 |---|---|
 | forest | `↑`/`↓` move through the sidebar list · `Enter` attach · `→` open tree view · wheel = zoom at cursor · drag = pan · click = select · double-click = open (canvas) / attach (sidebar) · `hjkl` pan · `+`/`-` zoom · `0` fit · `Tab` cycle by attention · `o` jump to most urgent · `a` attach · `n` new tree and attach · `r`/`L` rename tree · `A`/`Ctrl+X` archive/unarchive · `.` show/hide archived · `S` sidebar · `[`/`]` sidebar width · `x` kill agent · `R` relayout · `s` similar conversations · `/` search · `?` help |
-| tree | `↑`/`↓` or `j`/`k` move · `→`/`Enter` — on a tip (a node showing an agent's status): attach to that branch's agent (resume if dormant); on a `⋯` row: expand; on a `[+]` row: unfold; on any other message: grow a new branch there with its own agent and attach (from a question: *beside* it — the question stays out) · `f` flow (one branch's conversation) ⇄ full tree · `1`-`9` jump to a branch tip · `←`/`Esc` back to the forest · `b` branch menu (with/without agent) · `L` label · `r` rename tree · `/` search |
+| tree | `↑`/`↓` or `j`/`k` move · `→`/`Enter` — on a tip (a node showing an agent's status): attach to that branch's agent (resume if dormant); on a `⋯` row: expand; on a `[+]` row: unfold; on any other message: grow a new branch there with its own agent and attach (from a question: *beside* it — the question stays out) · `f` flow (one branch's conversation) ⇄ full tree · `Tab`/`Shift+Tab` next/prev branch · `1`-`9` jump to a branch tip · `←`/`Esc` back to the forest · `b` branch menu (with/without agent) · `L` label · `r` rename tree · `/` search |
 | attached pi | everything goes to pi, except the prefix `Ctrl+t`: `←`/`d` = back to tree · `f` = forest · `n` = next attention target · `Ctrl+t Ctrl+t` = send a literal Ctrl+t |
 
 Zooming is semantic: the sprite is the tree at every distance — maturity by
@@ -169,9 +169,10 @@ own navigation.)
 
 **Flow view** (`f`): narrows the transcript to one branch's conversation —
 the cursor's — root to tip, nothing else. The metro map keeps the whole
-shape with that route drawn bold, and the agents panel keeps every branch:
-jumping to another agent (`1`-`9`, click) switches the flow to it. `f`
-again restores the full tree.
+shape with the flow's route drawn bold while everything off it recedes to
+the grid gray, the flowed agent carries a `▸` in the panel, and the panel
+keeps every branch: `Tab`/`Shift+Tab` cycle the flow through them, and
+`1`-`9` or a click jumps straight to one. `f` again restores the full tree.
 
 **Search** (`/`): SQLite FTS5 over session names, every user message (abandoned
 branches included), compaction/branch summaries, and labels. `Enter` jumps to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edeng23/pines",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Tree-first orchestration TUI for pi coding agents. pi + trees = pines.",
   "license": "Apache-2.0",
   "author": "Eden Gaon",

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -466,7 +466,7 @@ export async function runApp(): Promise<void> {
       body = renderTreeBody(view);
       // The selected row explains what ⏎ does there; keep the bar terse and
       // front-load what narrow terminals would otherwise cut off.
-      hints = "⏎ attach/branch · ← forest · f flow · b branch · / search · L label · r rename · 1-9 branch · ↑↓ move ";
+      hints = "⏎ attach/branch · ← forest · f flow · ⇥ next branch · b branch · / search · L label · r rename · ↑↓ move ";
     }
     if (overlay) {
       composeOverlay(body, view);
@@ -883,7 +883,8 @@ export async function runApp(): Promise<void> {
         "forest   s=similar conversations (semantic neighbors of the selection)",
         "tree     j/k=move  ↵/→ = attach at a ● tip (an agent lives there), or grow",
         "tree     a branch: after a reply — or BESIDE a question (it stays out)",
-        "tree     f=flow (one branch's conversation) ⇄ full tree  1-9=go to branch",
+        "tree     f=flow (one branch's conversation) ⇄ full tree",
+        "tree     Tab/shift+Tab=next/prev branch (in flow: switches the flow)  1-9=nth",
         "tree     b=branch menu  L=label  r=rename this tree (its forest name)",
         `pi view  ${prefixName} ←/d=tree  ${prefixName} f=forest  ${prefixName} n=next attention`,
         `pi view  ${prefixName} ${prefixName}=send ${prefixName} to pi itself`,
@@ -1598,6 +1599,26 @@ export async function runApp(): Promise<void> {
           if (tip) gotoTipNode(tip.nodeId, tip.summary.treeId);
         }
         return;
+      case "\t":
+      case "\x1b[Z": {
+        // Cycle the branches: cursor to the next/previous tip — and in flow
+        // mode that IS switching flows, since the flow follows the cursor.
+        const tips = mode.view.tips;
+        if (tips.length === 0) return;
+        const selNode = mode.view.rows[mode.selected]?.a.nodeId;
+        const flowId = mode.flowTreeId;
+        const at = mode.flowOnly
+          ? tips.findIndex((t) => t.summary.treeId === flowId)
+          : tips.findIndex((t) => t.nodeId === selNode);
+        const dir = key === "\t" ? 1 : -1;
+        const next = tips[(((at < 0 ? 0 : at) + dir) % tips.length + tips.length) % tips.length]!;
+        gotoTipNode(next.nodeId, next.summary.treeId);
+        if (mode.flowOnly) {
+          const s = next.summary;
+          showToast(`flow ${next.num}/${tips.length}: ${next.headExcerpt ?? treeTitle(s).title}`);
+        }
+        return;
+      }
       case "\r":
       case "\x1b[C": {
         // ⏎/→: open ⋯/[+] rows; attach at a tip (an agent lives there);

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -938,7 +938,8 @@ export async function runApp(): Promise<void> {
         ];
     overlay = {
       kind: "menu",
-      title: `branch after: ${truncateStr(node?.excerpt || sel.nodeId, 48)}`,
+      // A question's branch lands BESIDE it, not after — say so up front.
+      title: `branch ${target.excludesSelected ? "beside" : "after"}: ${truncateStr(node?.excerpt || sel.nodeId, 48)}`,
       options,
       selected: 0,
       onPick: (idx) => {

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -61,9 +61,9 @@ import { FAINT, MUTED } from "./theme.js";
 import {
   aContainerOf,
   branchHeadOf,
+  branchTargetOf,
   buildConvView,
   cRowIndexOf,
-  exchangeEndOf,
   ownerOf,
   type ConvView,
 } from "./tree/sessionview.js";
@@ -121,6 +121,10 @@ type ViewMode =
       unfolded: Set<string>;
       selected: number;
       scroll: number;
+      /** Flow mode: show one session's conversation instead of the full tree. */
+      flowOnly: boolean;
+      /** Which session's flow (follows the cursor's branch); null = root. */
+      flowTreeId: string | null;
     }
   | { kind: "attached"; treeId: string };
 
@@ -462,7 +466,7 @@ export async function runApp(): Promise<void> {
       body = renderTreeBody(view);
       // The selected row explains what ⏎ does there; keep the bar terse and
       // front-load what narrow terminals would otherwise cut off.
-      hints = "⏎ attach/branch · ← forest · b branch · / search · L label · r rename · 1-9 branch · ↑↓ move ";
+      hints = "⏎ attach/branch · ← forest · f flow · b branch · / search · L label · r rename · 1-9 branch · ↑↓ move ";
     }
     if (overlay) {
       composeOverlay(body, view);
@@ -585,30 +589,46 @@ export async function runApp(): Promise<void> {
     if (mode.kind !== "tree") return;
     // No explicit focus: stay on the row under the cursor (live updates
     // rebuild the view constantly — the cursor must not jump around).
+    const m = mode; // narrowed alias: closures below must not re-widen it
     if (!focus) {
-      const cur = mode.view.rows[mode.selected]?.a;
+      const cur = m.view.rows[m.selected]?.a;
       if (cur) focus = { nodeId: cur.nodeId ?? cur.runId ?? cur.foldId ?? undefined };
     }
-    mode.view = buildConvView({
-      rootTreeId: mode.rootId,
-      detailOf: (id) => sessionDetails.get(id),
-      summaryOf,
-      childrenOf,
-      parentOf,
-      expandedRuns: mode.expandedRuns,
-      unfolded: mode.unfolded,
-      viewportH: vp().height,
-      wantDetail: fetchDetail,
-    });
-    let idx = -1;
-    if (focus?.nodeId && !focus.toLeaf) {
+    const build = () =>
+      buildConvView({
+        rootTreeId: m.rootId,
+        detailOf: (id) => sessionDetails.get(id),
+        summaryOf,
+        childrenOf,
+        parentOf,
+        expandedRuns: m.expandedRuns,
+        unfolded: m.unfolded,
+        viewportH: vp().height,
+        wantDetail: fetchDetail,
+        flowTreeId: m.flowOnly ? (m.flowTreeId ?? m.rootId) : null,
+      });
+    m.view = build();
+    const findFocus = () => {
+      if (!focus?.nodeId || focus.toLeaf) return -1;
       const id = focus.nodeId;
-      idx = mode.view.rows.findIndex(
+      return m.view.rows.findIndex(
         (r) => r.a.nodeId === id || r.a.runId === id || r.a.foldId === id,
       );
+    };
+    let idx = findFocus();
+    // Flow mode: a jump (search, panel, 1-9) may target a node on another
+    // branch — the flow follows the cursor, so switch to that node's session
+    // and rebuild once more rather than losing the jump.
+    if (idx < 0 && focus?.nodeId && m.flowOnly && m.view.detail.nodes[focus.nodeId]) {
+      const owner = ownerOf(m.view, focus.nodeId, (id) => sessionDetails.get(id));
+      if (owner && owner !== m.flowTreeId) {
+        m.flowTreeId = owner;
+        m.view = build();
+        idx = findFocus();
+      }
     }
-    if (idx < 0) idx = cRowIndexOf(mode.view, mode.view.leafId);
-    mode.selected = idx >= 0 ? idx : Math.max(0, mode.view.rows.length - 1);
+    if (idx < 0) idx = cRowIndexOf(m.view, m.view.leafId);
+    m.selected = idx >= 0 ? idx : Math.max(0, m.view.rows.length - 1);
   }
 
   function showToast(text: string): void {
@@ -637,6 +657,7 @@ export async function runApp(): Promise<void> {
       view: {
         rows: [],
         leafId: null,
+        flowTreeId: null,
         tips: [],
         atree: { rows: [], leafId: null, folded: false },
         detail: { treeId: rootId, leafId: null, rootIds: [], nodes: {} },
@@ -650,6 +671,8 @@ export async function runApp(): Promise<void> {
       unfolded: new Set(),
       selected: 0,
       scroll: 0,
+      flowOnly: false,
+      flowTreeId: null,
     };
     mode = treeMode;
     rebuildConv();
@@ -859,8 +882,9 @@ export async function runApp(): Promise<void> {
         "forest   A/ctrl+x=archive/unarchive tree  .=show/hide archived",
         "forest   s=similar conversations (semantic neighbors of the selection)",
         "tree     j/k=move  ↵/→ = attach at a ● tip (an agent lives there), or grow",
-        "tree     a new branch+agent from any other message  1-9=go to branch  b  L",
-        "tree     r=rename this tree (its forest name)",
+        "tree     a branch: after a reply — or BESIDE a question (it stays out)",
+        "tree     f=flow (one branch's conversation) ⇄ full tree  1-9=go to branch",
+        "tree     b=branch menu  L=label  r=rename this tree (its forest name)",
         `pi view  ${prefixName} ←/d=tree  ${prefixName} f=forest  ${prefixName} n=next attention`,
         `pi view  ${prefixName} ${prefixName}=send ${prefixName} to pi itself`,
         "search   / from forest or tree · ↑/↓ select · ↵ jump",
@@ -890,19 +914,28 @@ export async function runApp(): Promise<void> {
       return;
     }
     const node = sessionDetails.get(sel.treeId)?.nodes[sel.nodeId];
-    // A branch begins with YOUR next message, so it grows from the end of
-    // this exchange; re-answering (skipping the reply) is the explicit case.
-    const snapped = exchangeEndOf(mode.view.detail, sel.nodeId);
+    // A reply branches after its exchange. A user message branches from its
+    // PARENT — the question stays out of the new branch (sibling question,
+    // chat-edit style); re-answering (keep the question, fresh answer) is
+    // the explicit menu case.
+    const target = branchTargetOf(mode.view.detail, sel.nodeId);
+    const snapped = target.nodeId;
     const snapOwner =
       snapped === sel.nodeId
         ? sel.treeId
         : (ownerOf(mode.view, snapped, (id) => sessionDetails.get(id)) ?? sel.treeId);
     const canReanswer = snapped !== sel.nodeId;
-    const options = [
-      "branch + agent — your next message continues this exchange",
-      "branch only — a dormant branch after this exchange",
-      ...(canReanswer ? ["re-answer — discard nothing, ask this question again"] : []),
-    ];
+    const options = target.excludesSelected
+      ? [
+          "branch + agent — a sibling branch; this question stays out",
+          "branch only — a dormant sibling branch",
+          ...(canReanswer ? ["re-answer — keep this question, get a fresh answer"] : []),
+        ]
+      : [
+          "branch + agent — your next message continues this exchange",
+          "branch only — a dormant branch after this exchange",
+          ...(canReanswer ? ["re-answer — discard nothing, ask this question again"] : []),
+        ];
     overlay = {
       kind: "menu",
       title: `branch after: ${truncateStr(node?.excerpt || sel.nodeId, 48)}`,
@@ -1489,8 +1522,14 @@ export async function runApp(): Promise<void> {
   }
 
   /** Panel/mini click (or 1-9 by panel order): cursor to that branch tip. */
-  function gotoTipNode(nodeId: string): void {
+  function gotoTipNode(nodeId: string, treeId?: string): void {
     if (mode.kind !== "tree") return;
+    // In flow mode the flow follows the cursor: jumping to another branch's
+    // tip switches the shown conversation to that session.
+    if (mode.flowOnly) {
+      const tid = treeId ?? mode.view.tips.find((t) => t.nodeId === nodeId)?.summary.treeId;
+      if (tid) mode.flowTreeId = tid;
+    }
     rebuildConv({ nodeId });
     requestRender();
   }
@@ -1555,7 +1594,7 @@ export async function runApp(): Promise<void> {
       case "9":
         {
           const tip = mode.view.tips[Number(key) - 1];
-          if (tip) gotoTipNode(tip.nodeId);
+          if (tip) gotoTipNode(tip.nodeId, tip.summary.treeId);
         }
         return;
       case "\r":
@@ -1583,9 +1622,11 @@ export async function runApp(): Promise<void> {
             attachTip(row.tips);
             return;
           }
-          // A branch BEGINS with a user message: quick-branching from a
-          // question (or mid-run) lands after its answer, never beside it.
-          const snapped = exchangeEndOf(mode.view.detail, row.a.nodeId);
+          // Where the new branch forks from: a reply branches after its
+          // exchange; a USER message branches from its parent — the question
+          // stays out, so the next message replaces it as a sibling (the way
+          // editing a message works in chat UIs).
+          const snapped = branchTargetOf(mode.view.detail, row.a.nodeId).nodeId;
           // An unused fork already parked here? Resume it instead of
           // minting yet another session file for the same spot.
           const parked =
@@ -1610,6 +1651,27 @@ export async function runApp(): Promise<void> {
       case "r":
         void renameTreeFlow();
         return;
+      case "f": {
+        // Flow ⇄ full tree. The flow is the cursor's branch: the session of
+        // the tip under the cursor, else the session owning the cursor's node.
+        mode.flowOnly = !mode.flowOnly;
+        if (mode.flowOnly) {
+          const row = mode.view.rows[mode.selected];
+          const nodeId = row?.a.nodeId;
+          mode.flowTreeId =
+            row?.tips?.[0]?.treeId ??
+            (nodeId ? ownerOf(mode.view, nodeId, (id) => sessionDetails.get(id)) : undefined) ??
+            mode.rootId;
+        }
+        rebuildConv();
+        showToast(
+          mode.flowOnly
+            ? "flow — this branch's conversation only (f: back to the full tree)"
+            : "full tree",
+        );
+        requestRender();
+        return;
+      }
       case "S":
         ui.sidebarVisible = !ui.sidebarVisible;
         saveUiState(ui);

--- a/src/client/tree/convmap.ts
+++ b/src/client/tree/convmap.ts
@@ -162,6 +162,8 @@ export function renderConvMini(
     height: number;
     spinnerFrame: number;
     cursorSkelId?: string | null;
+    /** Skeleton ids on the flow's route — drawn bold (flow mode highlight). */
+    routeIds?: Set<string>;
   },
 ): ConvMini {
   const { width: w, height: h } = opts;
@@ -195,6 +197,11 @@ export function renderConvMini(
     railSgr[y]![x] = sgr;
   };
 
+  // The flow's route reads bold: a rail is on the route when both of its
+  // endpoints are (root → tip is a single ancestor chain in the skeleton).
+  const onRoute = (i: number): boolean => opts.routeIds?.has(nodes[i]!.id) ?? false;
+  const boldIf = (b: boolean, sgr: string): string => (b ? `1;${sgr}` : sgr);
+
   // Routes, per parent: a short horizontal stub out of the parent into a
   // vertical spine, then rounded elbows fanning to each child's station.
   nodes.forEach((p, pi) => {
@@ -203,13 +210,21 @@ export function renderConvMini(
     const cx = Math.min(...kids.map((k) => k.x));
     const sx = Math.max(p.x + 1, Math.min(p.x + 2, cx - 1));
     // Attachment rows on the spine: the parent's and every child's.
+    const parentOnRoute = onRoute(pi) && kids.some((k) => onRoute(nodes.indexOf(k)));
     const rows = [
-      { y: p.y, x: p.x, sgr: laneOf[pi]!, from: "parent" as const },
+      {
+        y: p.y,
+        x: p.x,
+        sgr: boldIf(parentOnRoute, laneOf[pi]!),
+        from: "parent" as const,
+        route: parentOnRoute,
+      },
       ...kids.map((k) => ({
         y: k.y,
         x: k.x,
-        sgr: laneOf[nodes.indexOf(k)]!,
+        sgr: boldIf(onRoute(pi) && onRoute(nodes.indexOf(k)), laneOf[nodes.indexOf(k)]!),
         from: "child" as const,
+        route: onRoute(pi) && onRoute(nodes.indexOf(k)),
       })),
     ].sort((a, b) => a.y - b.y);
     const topY = rows[0]!.y;
@@ -235,23 +250,24 @@ export function renderConvMini(
   });
 
   // Stations last: they sit on top of the rails.
-  for (const n of nodes) {
+  nodes.forEach((n, i) => {
     const here = n.id === opts.cursorSkelId;
+    const route = onRoute(i);
     const tip = n.tips?.[0];
     if (tip) {
       glyph[n.y]![n.x] = {
         ch: statusGlyph(tip, opts.spinnerFrame),
-        sgr: here ? "7" : statusSgr(tip),
+        sgr: here ? "7" : boldIf(route, statusSgr(tip)),
       };
       hits.set(miniHitKey(n.x, n.y), n.id);
       hits.set(miniHitKey(n.x + 1, n.y), n.id);
       hits.set(miniHitKey(n.x - 1, n.y), n.id);
     } else if (n.parent === -1) {
-      glyph[n.y]![n.x] = { ch: "○", sgr: here ? "7" : "36" };
+      glyph[n.y]![n.x] = { ch: "○", sgr: here ? "7" : boldIf(route, "36") };
     } else {
-      glyph[n.y]![n.x] = { ch: "·", sgr: here ? "7" : MUTED };
+      glyph[n.y]![n.x] = { ch: "·", sgr: here ? "7" : boldIf(route, MUTED) };
     }
-  }
+  });
 
   const lines: string[] = [];
   for (let y = 0; y < h; y++) {

--- a/src/client/tree/convmap.ts
+++ b/src/client/tree/convmap.ts
@@ -10,7 +10,7 @@
  * cursor is highlighted so the mini doubles as a you-are-here marker.
  */
 import { statusGlyph, statusSgr } from "../forest/view.js";
-import { FAINT, MUTED } from "../theme.js";
+import { FAINT, GRID, MUTED } from "../theme.js";
 import { spliceCustom } from "./lanegraph.js";
 import type { TreeDetail, TreeSummary } from "../../shared/types.js";
 
@@ -197,10 +197,13 @@ export function renderConvMini(
     railSgr[y]![x] = sgr;
   };
 
-  // The flow's route reads bold: a rail is on the route when both of its
-  // endpoints are (root → tip is a single ancestor chain in the skeleton).
+  // Flow highlight works by CONTRAST, not just weight: the route is drawn
+  // bold while everything off it recedes to the grid gray — bold alone is
+  // invisible in half the terminal fonts. A rail is on the route when both
+  // of its endpoints are (root → tip is one ancestor chain in the skeleton).
+  const dimming = !!opts.routeIds;
   const onRoute = (i: number): boolean => opts.routeIds?.has(nodes[i]!.id) ?? false;
-  const boldIf = (b: boolean, sgr: string): string => (b ? `1;${sgr}` : sgr);
+  const boldIf = (b: boolean, sgr: string): string => (b ? `1;${sgr}` : dimming ? GRID : sgr);
 
   // Routes, per parent: a short horizontal stub out of the parent into a
   // vertical spine, then rounded elbows fanning to each child's station.
@@ -249,7 +252,9 @@ export function renderConvMini(
     }
   });
 
-  // Stations last: they sit on top of the rails.
+  // Stations last: they sit on top of the rails. Off-route agent tips keep
+  // their status COLOR (status is information, never dimmed) but lose bold;
+  // off-route structure (roots, interior dots) recedes with the rails.
   nodes.forEach((n, i) => {
     const here = n.id === opts.cursorSkelId;
     const route = onRoute(i);
@@ -257,15 +262,15 @@ export function renderConvMini(
     if (tip) {
       glyph[n.y]![n.x] = {
         ch: statusGlyph(tip, opts.spinnerFrame),
-        sgr: here ? "7" : boldIf(route, statusSgr(tip)),
+        sgr: here ? "7" : route ? `1;${statusSgr(tip)}` : statusSgr(tip),
       };
       hits.set(miniHitKey(n.x, n.y), n.id);
       hits.set(miniHitKey(n.x + 1, n.y), n.id);
       hits.set(miniHitKey(n.x - 1, n.y), n.id);
     } else if (n.parent === -1) {
-      glyph[n.y]![n.x] = { ch: "○", sgr: here ? "7" : boldIf(route, "36") };
+      glyph[n.y]![n.x] = { ch: "○", sgr: here ? "7" : route ? "1;36" : dimming ? GRID : "36" };
     } else {
-      glyph[n.y]![n.x] = { ch: "·", sgr: here ? "7" : boldIf(route, MUTED) };
+      glyph[n.y]![n.x] = { ch: "·", sgr: here ? "7" : route ? "1" : dimming ? GRID : MUTED };
     }
   });
 

--- a/src/client/tree/sessionview.ts
+++ b/src/client/tree/sessionview.ts
@@ -199,12 +199,19 @@ export function buildConvView(input: ConvViewInput): ConvView {
       flowPath = new Set<string>();
       let cur: string | null = tip.nodeId;
       for (let guard = 0; cur && guard < 100_000; guard++) {
+        // Resolve BEFORE adding: a root may legally carry a parentId that
+        // isn't in the file (toTreeDetail keeps it verbatim), and this is
+        // the codebase's first upward walk — it must stop at the family's
+        // edge, not admit a dangling id the rebuild below would crash on.
+        const n: NodeSummary | undefined = merged.detail.nodes[cur];
+        if (!n) break;
         flowPath.add(cur);
-        cur = merged.detail.nodes[cur]?.parentId ?? null;
+        cur = n.parentId ?? null;
       }
       const nodes: Record<string, NodeSummary> = {};
       for (const id of flowPath) {
-        const n = merged.detail.nodes[id]!;
+        const n = merged.detail.nodes[id];
+        if (!n) continue;
         nodes[id] = { ...n, children: n.children.filter((c) => flowPath!.has(c)) };
       }
       renderDetail = {

--- a/src/client/tree/sessionview.ts
+++ b/src/client/tree/sessionview.ts
@@ -45,6 +45,10 @@ export interface ConvView {
   rows: ConvRow[];
   /** Merged-tree leaf: the most recently active branch's end. */
   leafId: string | null;
+  /** Flow mode: the session whose linear conversation the rows show. */
+  flowTreeId: string | null;
+  /** Node ids on the flow's path (root → tip); set only in flow mode. */
+  flowPath?: Set<string>;
   /** Branches worth seeing, ordered as they appear in the transcript. */
   tips: PanelTip[];
   /** Dormant never-continued forks, by node — invisible until reused. */
@@ -74,6 +78,13 @@ export interface ConvViewInput {
   now?: number;
   /** Called for family members whose detail isn't cached yet (async fetch). */
   wantDetail?: (treeId: string) => void;
+  /**
+   * Flow mode: show only this session's conversation — the linear path from
+   * the root to its tip — instead of the whole merged family. The metro map
+   * keeps the full structure (with the flow's route highlighted); the panel
+   * keeps every agent, so jumping to one switches the flow.
+   */
+  flowTreeId?: string | null;
 }
 
 /**
@@ -115,6 +126,30 @@ export function exchangeEndOf(detail: TreeDetail, nodeId: string): string {
   return cur;
 }
 
+export interface BranchTarget {
+  nodeId: string;
+  /** True when the selected message itself stays OUT of the new branch. */
+  excludesSelected: boolean;
+}
+
+/**
+ * Where a branch grown at `nodeId` actually forks from.
+ *
+ * A reply (or tool run): the end of its exchange — branching from an answer
+ * lands after it. A USER message: its parent — the question is not part of
+ * the new branch, so your next message replaces it as a sibling (the way
+ * editing a message works in chat UIs) and the old answer can never read as
+ * answering the new question. A root question has nothing before it and
+ * falls back to exchange end.
+ */
+export function branchTargetOf(detail: TreeDetail, nodeId: string): BranchTarget {
+  const node = detail.nodes[nodeId];
+  if (node?.kind === "user" && node.parentId && detail.nodes[node.parentId]) {
+    return { nodeId: node.parentId, excludesSelected: true };
+  }
+  return { nodeId: exchangeEndOf(detail, nodeId), excludesSelected: false };
+}
+
 export function buildConvView(input: ConvViewInput): ConvView {
   const family = familyOf(
     input.rootTreeId,
@@ -150,12 +185,43 @@ export function buildConvView(input: ConvViewInput): ConvView {
     else shownAt.set(t.nodeId, [t.summary]);
   }
 
-  const atree = buildAsciiTree(merged.detail, {
+  // FLOW MODE: prune the transcript to one session's path — root to that
+  // session's tip, shared prefix included. The full merged detail stays in
+  // the view (ancestry walks, branch targets, the metro map all use it);
+  // only what the transcript RENDERS narrows.
+  let renderDetail = merged.detail;
+  let flowTreeId: string | null = null;
+  let flowPath: Set<string> | undefined;
+  if (input.flowTreeId) {
+    const tip = merged.tips.find((t) => t.summary.treeId === input.flowTreeId);
+    if (tip) {
+      flowTreeId = input.flowTreeId;
+      flowPath = new Set<string>();
+      let cur: string | null = tip.nodeId;
+      for (let guard = 0; cur && guard < 100_000; guard++) {
+        flowPath.add(cur);
+        cur = merged.detail.nodes[cur]?.parentId ?? null;
+      }
+      const nodes: Record<string, NodeSummary> = {};
+      for (const id of flowPath) {
+        const n = merged.detail.nodes[id]!;
+        nodes[id] = { ...n, children: n.children.filter((c) => flowPath!.has(c)) };
+      }
+      renderDetail = {
+        treeId: merged.detail.treeId,
+        leafId: tip.nodeId,
+        rootIds: merged.detail.rootIds.filter((r) => flowPath!.has(r)),
+        nodes,
+      };
+    }
+  }
+
+  const atree = buildAsciiTree(renderDetail, {
     expandedRuns: input.expandedRuns,
     unfolded: input.unfolded,
     viewportH: input.viewportH,
     now: input.now,
-    keep: new Set(shownAt.keys()),
+    keep: new Set([...shownAt.keys()].filter((id) => !flowPath || flowPath.has(id))),
   });
 
   const rows: ConvRow[] = atree.rows.map((a) => ({
@@ -211,7 +277,10 @@ export function buildConvView(input: ConvViewInput): ConvView {
 
   return {
     rows,
-    leafId: merged.detail.leafId,
+    // In flow mode the "story so far" ends at the flow's own tip.
+    leafId: renderDetail.leafId,
+    flowTreeId,
+    flowPath,
     tips,
     parkedAt,
     parkedCount,

--- a/src/client/tree/view.ts
+++ b/src/client/tree/view.ts
@@ -9,7 +9,7 @@
  */
 import { clipAnsi, visibleLength } from "../ansi.js";
 import { FAINT, MUTED } from "../theme.js";
-import { exchangeEndOf, type ConvView } from "./sessionview.js";
+import { branchTargetOf, type ConvView } from "./sessionview.js";
 import type { TreeSummary } from "../../shared/types.js";
 import { statusGlyph, statusSgr } from "../forest/view.js";
 
@@ -123,12 +123,14 @@ export function renderConversation(
         if (tips.length > 1) body += ` \x1b[${MUTED}m(+${tips.length - 1})${RESET}`;
         if (isSel) body += ` \x1b[${MUTED}m(⏎ ${t.live ? "attach" : "resume"})${RESET}`;
       } else if (isSel && row.nodeId) {
-        const snapped = exchangeEndOf(view.detail, row.nodeId);
+        const target = branchTargetOf(view.detail, row.nodeId);
         const parkedHere =
-          view.parkedAt.get(snapped)?.length ?? view.parkedAt.get(row.nodeId)?.length;
+          view.parkedAt.get(target.nodeId)?.length ?? view.parkedAt.get(row.nodeId)?.length;
         body += parkedHere
           ? ` \x1b[${MUTED}m(⏎ continue from here — reuses a parked agent)${RESET}`
-          : ` \x1b[${MUTED}m(⏎ new branch + agent from here)${RESET}`;
+          : target.excludesSelected
+            ? ` \x1b[${MUTED}m(⏎ new branch before this message — it stays out)${RESET}`
+            : ` \x1b[${MUTED}m(⏎ new branch + agent from here)${RESET}`;
       }
     } else if (row.kind === "elision") {
       const sgr = isSel ? "7" : MUTED;
@@ -191,8 +193,9 @@ export function renderConversation(
   if (lay.sideW > 0) {
     const side: string[] = [];
     const n = view.tips.length;
+    const flowTag = view.flowTreeId ? ` \x1b[1m· flow${RESET}\x1b[${MUTED}m` : "";
     side.push(
-      clipAnsi(`\x1b[${MUTED}m agents on this tree — ${n}${RESET}`, lay.sideW),
+      clipAnsi(`\x1b[${MUTED}m agents on this tree — ${n}${flowTag}${RESET}`, lay.sideW),
     );
     side.push("");
     const selRow = view.rows[opts.selected]?.a;
@@ -209,6 +212,10 @@ export function renderConversation(
         height: lay.mapH,
         spinnerFrame: opts.spinnerFrame,
         cursorSkelId,
+        // Flow mode: the shown session's route reads bold on the map.
+        routeIds: view.flowPath
+          ? new Set(view.skel.filter((s) => view.flowPath!.has(s.id)).map((s) => s.id))
+          : undefined,
       });
       miniHits = mini.hits;
       for (const l of mini.lines) side.push(l);

--- a/src/client/tree/view.ts
+++ b/src/client/tree/view.ts
@@ -232,8 +232,11 @@ export function renderConversation(
       const info = quiet
         ? `\x1b[${MUTED}m· ${humanAge(s.mtime, opts.now)}${RESET}`
         : `\x1b[${MUTED}m· ${stateWord(s)} · ${humanAge(s.mtime, opts.now)}${RESET}`;
-      const nameSgr = !s.seen ? "1" : here ? "1" : s.live ? "0" : MUTED;
-      const line = ` ${glyph} \x1b[${nameSgr}m${label}${RESET} ${info}`;
+      // Flow mode: the flowed branch is THE one on screen — mark its row.
+      const flowed = view.flowTreeId === s.treeId;
+      const lead = flowed ? `\x1b[1m▸${RESET}` : " ";
+      const nameSgr = !s.seen || here || flowed ? "1" : s.live ? "0" : MUTED;
+      const line = `${lead}${glyph} \x1b[${nameSgr}m${label}${RESET} ${info}`;
       if (here) {
         const clipped = clipAnsi(line, lay.sideW);
         const fill = Math.max(0, lay.sideW - visibleLength(clipped));

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -285,8 +285,13 @@ export class Daemon {
       else if (!rec.name || rec.name === basename(rec.cwd ?? "")) {
         rec.name = deriveTreeName(parsed) ?? rec.name;
       }
-      // A live extension is the leaf authority; files are authoritative when dormant.
-      if (!rec.extensionConnected) rec.leafId = parsed.leafId;
+      // Leaf authority: a live extension's word wins while its agent is IDLE
+      // (the user may have navigated the tree up, away from the file tail) —
+      // but the extension only reports a new leaf on settle, so while the
+      // agent is RUNNING the growing file's tail is the truth. Without this,
+      // the tip pins to the previous settle point for the whole run while
+      // the transcript shows the new messages.
+      if (!rec.extensionConnected || rec.status === "running") rec.leafId = parsed.leafId;
       if (rec.parentSessionPath && !rec.parentEntryId) {
         void this.computeForkPoint(rec, parsed);
       }
@@ -649,7 +654,11 @@ export class Daemon {
     try {
       const parsed = await parseSessionFile(rec.sessionPath);
       const detail = toTreeDetail(rec.treeId, parsed);
-      if (rec.extensionConnected && rec.leafId) detail.leafId = rec.leafId;
+      // Same rule as ingest: extension leaf wins only while idle — a running
+      // agent's leaf is wherever the file just grew to.
+      if (rec.extensionConnected && rec.leafId && rec.status !== "running") {
+        detail.leafId = rec.leafId;
+      }
       client.wire.send({ t: "result", re: msg.id, ok: true, tree: detail });
     } catch (err) {
       this.fail(client, msg.id, err);

--- a/test/fixtures/fake-pi.mjs
+++ b/test/fixtures/fake-pi.mjs
@@ -53,7 +53,9 @@ if (process.env.PINES_SOCK && (args.includes("--ext-report") || process.env.FAKE
           ? args[args.indexOf("--session") + 1]
           : `/tmp/fake-session-${process.pid}.jsonl`),
       sessionId: "fake0000",
-      leafId: null,
+      // Real pi reports its current leaf on hello; tests exercising leaf
+      // authority (extension vs growing file) inject one here.
+      leafId: process.env.FAKE_PI_LEAF ?? null,
     });
     send({ t: "ev", type: "agent_start" });
     const settleMs = Number(process.env.FAKE_PI_SETTLE_MS ?? 600);

--- a/test/running-leaf.test.ts
+++ b/test/running-leaf.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Leaf authority while an agent WORKS: the extension only reports a new leaf
+ * on settle, so mid-run the growing session file's tail is the truth. The
+ * tip/attach pointer must follow the newest message, not pin to the previous
+ * settle point (which is exactly what the extension's last word says).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type ChildProcess } from "node:child_process";
+import { connect, type Socket } from "node:net";
+import { appendFileSync, chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Wire } from "../src/shared/wire.js";
+import { PROTOCOL_VERSION } from "../src/shared/protocol.js";
+import { branchedSession, msg } from "./fixtures/sessions.js";
+import { FAKE_PI, startDaemon, waitFor } from "./fixtures/daemon.js";
+
+let home: string;
+let fixtureSession: string;
+let daemon: ChildProcess;
+let sockPath: string;
+
+function connectClient(): Promise<{ wire: Wire; sock: Socket; inbox: unknown[] }> {
+  return new Promise((resolve, reject) => {
+    const sock = connect(sockPath);
+    sock.once("error", reject);
+    const inbox: unknown[] = [];
+    const wire = new Wire(sock);
+    wire.on("msg", (m) => inbox.push(m));
+    sock.once("connect", () => {
+      wire.send({ t: "hello", role: "client", protocolVersion: PROTOCOL_VERSION, cols: 100, rows: 30 });
+      resolve({ wire, sock, inbox });
+    });
+  });
+}
+
+function upserts(inbox: unknown[]): Array<Record<string, unknown>> {
+  return inbox
+    .filter((m) => (m as { t?: string }).t === "forest_update")
+    .flatMap((m) => ((m as { upsert?: Array<Record<string, unknown>> }).upsert ?? []));
+}
+
+function result(inbox: unknown[], re: string): Record<string, unknown> | undefined {
+  return inbox.find(
+    (m): m is Record<string, unknown> =>
+      typeof m === "object" && m !== null && (m as { re?: string }).re === re,
+  );
+}
+
+beforeAll(async () => {
+  home = mkdtempSync(join(tmpdir(), "pines-runleaf-"));
+  const sessionsRoot = join(home, "pi-sessions");
+  const dir = join(sessionsRoot, "--tmp-proj--");
+  mkdirSync(dir, { recursive: true });
+  fixtureSession = join(dir, "2026-01-01T00-00-00-000Z_22222222.jsonl");
+  writeFileSync(fixtureSession, branchedSession("/tmp/proj").content);
+
+  chmodSync(FAKE_PI, 0o755);
+  const started = await startDaemon({
+    home,
+    env: {
+      PINES_PI_BIN: FAKE_PI,
+      PINES_PI_SESSIONS: sessionsRoot,
+      FAKE_PI_EXT: "1",
+      FAKE_PI_SESSION: fixtureSession,
+      // The extension's last word: an OLD leaf (the fixture's a2), and a
+      // settle far in the future — the agent stays "running" for the test.
+      FAKE_PI_LEAF: "aaaa0004",
+      FAKE_PI_SETTLE_MS: "60000",
+    },
+  });
+  daemon = started.proc;
+  sockPath = started.sockPath;
+});
+
+afterAll(() => {
+  daemon?.kill("SIGKILL");
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("leaf authority while running", () => {
+  it("get_tree follows the growing file's tail mid-run, not the stale extension leaf", async () => {
+    const c = await connectClient();
+    await waitFor(() => c.inbox.find((m) => (m as { t?: string }).t === "hello_ok"), 5000, "hello_ok");
+
+    c.wire.send({ t: "spawn_tree", id: "s1", cwd: home });
+    const spawned = await waitFor(() => result(c.inbox, "s1"), 8000, "spawn result");
+    expect(spawned.ok).toBe(true);
+
+    // Extension hello binds the fixture; agent_start makes it "running".
+    const running = await waitFor(
+      () => upserts(c.inbox).find((t) => t.sessionPath === fixtureSession && t.status === "running"),
+      8000,
+      "running status",
+    );
+    const treeId = running.treeId as string;
+
+    // The conversation grows mid-run: a new user turn lands in the file.
+    appendFileSync(fixtureSession, msg("bbbb0001", "aaaa0004", "user", "one more thing") + "\n");
+    await waitFor(
+      () => (upserts(c.inbox).some((t) => t.treeId === treeId && t.leafId === "bbbb0001") ? true : undefined),
+      8000,
+      "leaf follows the file tail",
+    );
+
+    // get_tree agrees: the tip sits on the new message, not the old settle
+    // point the extension reported on hello.
+    c.wire.send({ t: "get_tree", id: "g1", treeId });
+    const res = await waitFor(() => result(c.inbox, "g1"), 8000, "get_tree result");
+    expect(res.ok).toBe(true);
+    expect((res.tree as { leafId: string }).leafId).toBe("bbbb0001");
+  }, 30_000);
+});

--- a/test/sessionview.test.ts
+++ b/test/sessionview.test.ts
@@ -250,6 +250,23 @@ describe("conversation view", () => {
     expect(f.rows.map((row) => row.a.nodeId).filter(Boolean)).toContain("u2");
   });
 
+  it("flow mode survives a root whose parentId points outside the family", () => {
+    // toTreeDetail legally produces roots that keep a verbatim parentId not
+    // present in the file — the upward walk must stop at the family's edge,
+    // not crash the rebuild on a dangling ancestor.
+    const dangling = rootDetail();
+    dangling.nodes["u1"] = { ...dangling.nodes["u1"]!, parentId: "gone0000" };
+    const v = buildConvView(
+      harness({
+        detailOf: (id) => (id === "root" ? dangling : kidDetail()),
+        flowTreeId: "root",
+      }),
+    );
+    const shown = v.rows.map((r) => r.a.nodeId).filter(Boolean);
+    expect(shown).toEqual(expect.arrayContaining(["u1", "a1", "u2", "a2"]));
+    expect(v.flowPath!.has("gone0000")).toBe(false);
+  });
+
   it("streams in: missing member details are requested, view stays usable", () => {
     const wanted: string[] = [];
     const v = buildConvView(

--- a/test/sessionview.test.ts
+++ b/test/sessionview.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  branchTargetOf,
   buildConvView,
   cRowIndexOf,
   exchangeEndOf,
@@ -222,6 +223,33 @@ describe("conversation view", () => {
     expect(v.pendingMembers).toBe(0);
   });
 
+  it("flow mode shows one session's path only, keeping the full map and panel", () => {
+    const v = buildConvView(harness({ flowTreeId: "kid" }));
+    const shownNodes = v.rows.map((r) => r.a.nodeId).filter(Boolean);
+    // Only the kid's conversation: shared prefix + its own turns. The
+    // root's divergent exchange (u2 → a2) leaves the transcript entirely.
+    expect(shownNodes).toEqual(expect.arrayContaining(["u1", "a1", "u3", "a3"]));
+    expect(shownNodes).not.toContain("u2");
+    expect(shownNodes).not.toContain("a2");
+    expect(v.leafId).toBe("a3");
+    expect(v.flowTreeId).toBe("kid");
+    expect(v.flowPath).toEqual(new Set(["u1", "a1", "u3", "a3"]));
+    // The metro map keeps the WHOLE structure; the panel keeps every agent.
+    expect(v.detail.nodes["a2"]).toBeDefined();
+    expect(v.tips.map((t) => t.summary.treeId)).toEqual(
+      expect.arrayContaining(["root", "kid"]),
+    );
+    // Flowing the root hides the kid's turns instead.
+    const r = buildConvView(harness({ flowTreeId: "root" }));
+    const rootNodes = r.rows.map((row) => row.a.nodeId).filter(Boolean);
+    expect(rootNodes).toContain("a2");
+    expect(rootNodes).not.toContain("u3");
+    // An unknown flow session falls back to the full tree.
+    const f = buildConvView(harness({ flowTreeId: "nope" }));
+    expect(f.flowTreeId).toBeNull();
+    expect(f.rows.map((row) => row.a.nodeId).filter(Boolean)).toContain("u2");
+  });
+
   it("streams in: missing member details are requested, view stays usable", () => {
     const wanted: string[] = [];
     const v = buildConvView(
@@ -389,5 +417,28 @@ describe("branch identity and exchange snapping", () => {
     expect(exchangeEndOf(d, "t1")).toBe("a1"); // mid-run too
     expect(exchangeEndOf(d, "a1")).toBe("a1"); // a reply is already the end
     expect(exchangeEndOf(d, "u2")).toBe("u2"); // nothing to follow
+  });
+
+  it("branchTargetOf: a question branches BESIDE itself, a reply after itself", () => {
+    const d: TreeDetail = {
+      treeId: "t",
+      leafId: "a1",
+      rootIds: ["u1"],
+      nodes: {
+        u1: node("u1", null, "user", ["t1"]),
+        t1: node("t1", "u1", "tool", ["a1"]),
+        a1: node("a1", "t1", "assistant", ["u2"]),
+        u2: node("u2", "a1", "user", []),
+      },
+    };
+    // A user message forks from its parent — the question is NOT part of
+    // the new branch (chat-edit semantics), so the old answer can never
+    // read as answering the new question.
+    expect(branchTargetOf(d, "u2")).toEqual({ nodeId: "a1", excludesSelected: true });
+    // A reply (or mid-run tool) still branches after its exchange.
+    expect(branchTargetOf(d, "a1")).toEqual({ nodeId: "a1", excludesSelected: false });
+    expect(branchTargetOf(d, "t1")).toEqual({ nodeId: "a1", excludesSelected: false });
+    // A root question has nothing before it: falls back to exchange end.
+    expect(branchTargetOf(d, "u1")).toEqual({ nodeId: "a1", excludesSelected: false });
   });
 });


### PR DESCRIPTION
Three tree-view refinements, plus the bump to 0.1.4 (merging releases it).

## Flow view (`f`)

The transcript can now narrow to **one branch's conversation** — the cursor's — root to tip, instead of the full merged family. The metro map keeps the whole structure with the flow's route drawn **bold**, and the agents panel keeps every branch: `1`-`9` or a click on another agent switches the flow to that session. Jumps that target an off-flow node (search) switch the flow to the target's session rather than losing the jump; an unknown/pending flow session falls back to the full tree. Full tree stays the default; `f` toggles back.

## The tip follows a working agent

The extension only reports a new leaf on `agent_settled`, but the daemon treated its word as authoritative whenever connected — so during a run the transcript showed the new messages while the tip (status suffix, ⏎-attach target) stayed pinned to the *previous* settle point. Now, while an agent is **running**, the growing session file's tail is the leaf truth (both in ingest and `get_tree`); extension authority still applies when idle, which is when user navigation can legitimately diverge from the tail. Integration test: a fake pi reporting a stale hello leaf with settle 60s out — appending to the session mid-run moves both the broadcast leaf and `get_tree`'s.

## Branching from a question lands beside it

Pointing at a **user message** and branching now forks from its *parent*: the question is not part of the new branch, so your next message replaces it as a sibling (chat-edit semantics) and the old answer can never read as answering the new question. Replies (and mid-run tool rows) still branch after their exchange; the `b` menu's *re-answer* (keep the question, regenerate the answer) stays, with clarified labels; a root question falls back to exchange-end. One shared `branchTargetOf` drives ⏎, the `b` menu, and the inline hint, and is unit-tested for all four cases.

Docs (key table, branching + flow sections, help overlay, hints) updated. Suite: 30 files / **153 tests green**, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QuVLfbJnrCTPHCmyqsqTh

---
_Generated by [Claude Code](https://claude.ai/code/session_019QuVLfbJnrCTPHCmyqsqTh)_