### PR TITLE
v0.1.5: chunk-set similarity with receipts — match conversations, not blended vectors

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -202,9 +202,16 @@ trees never jump**; `R` refits. Offline or before the model warms, a
 deterministic lexical layout (cwd clusters on a spiral, recency rings) applies
 — the forest always loads instantly.
 
-**Similar trees** (`s`): ranks the forest by cosine similarity to the selected
-tree (same embeddings, brute force — instant at forest scale) and jumps the
-camera to the picked neighbor.
+**Similar trees** (`s`): ranks the forest against the selected tree in two
+stages — a cheap pooled-cosine shortlist over everything, then an exact
+re-rank that *matches the two trees' chunks* (each message finds its best
+counterpart on the other side, recency-weighted). Matching chunk sets, not
+blended vectors, means a conversation that covers two topics ranks well
+against both — and every score comes with receipts: the selected hit shows
+the top matching message pairs, with `⚙` marking matches that come from
+tool activity (same files) rather than topic. Picking a neighbor jumps the
+camera to it. Note the map is the *approximate* view (pooled vectors,
+projected to 2-D for stability); the `s` list is the honest one.
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edeng23/pines",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Tree-first orchestration TUI for pi coding agents. pi + trees = pines.",
   "license": "Apache-2.0",
   "author": "Eden Gaon",

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -12,7 +12,7 @@ import { homedir } from "node:os";
 import { DaemonClient } from "./daemon-client.js";
 import { pinesHome } from "../shared/paths.js";
 import { startBoot } from "./boot.js";
-import type { SearchHit, TreeDetail, TreeSummary, Camera } from "../shared/types.js";
+import type { SearchHit, SimilarEvidence, TreeDetail, TreeSummary, Camera } from "../shared/types.js";
 import {
   InputRouter,
   MOUSE_ENABLE,
@@ -136,6 +136,8 @@ type Overlay =
       options: string[];
       selected: number;
       onPick: (index: number) => void;
+      /** Per-option detail lines, rendered under the list for the selection. */
+      detail?: (string[] | undefined)[];
     }
   | {
       kind: "input";
@@ -528,6 +530,13 @@ export async function runApp(): Promise<void> {
         const cursor = i === (overlay as { selected: number }).selected ? "\x1b[7m" : "";
         lines.push(bar(` ${cursor} ${opt} \x1b[0m`));
       });
+      // The selected option's receipts (e.g. WHY a similar hit scored what
+      // it did) live under the list, so the list itself stays scannable.
+      const detail = overlay.detail?.[overlay.selected];
+      if (detail?.length) {
+        lines.push(`${pad}├${"─".repeat(inner)}┤`);
+        for (const d of detail) lines.push(bar(` ${d}`));
+      }
     }
     lines.push(`${pad}\x1b[0m╰${"─".repeat(inner)}╯`);
     const top = Math.max(1, Math.floor((view.height - lines.length) / 3));
@@ -719,15 +728,17 @@ export async function runApp(): Promise<void> {
       return;
     }
     // Hits are session files; the user thinks in conversations. Fold each
-    // hit to its family root, keep the best score per family, and drop the
-    // anchor's own family — a fork of the same conversation is not a find.
+    // hit to its family root, keep the best-scoring member per family (the
+    // list arrives ranked, so first wins — its evidence rides along), and
+    // drop the anchor's own family — a fork of the same conversation is not
+    // a find.
     const seen = new Set<string>([familyRootId(treeId)]);
-    const hits: { rootId: string; score: number }[] = [];
+    const hits: { rootId: string; score: number; evidence?: SimilarEvidence[] }[] = [];
     for (const h of res.similar ?? []) {
       const rootId = familyRootId(h.treeId);
       if (seen.has(rootId)) continue;
       seen.add(rootId);
-      hits.push({ rootId, score: h.score });
+      hits.push({ rootId, score: h.score, evidence: h.evidence });
     }
     if (hits.length === 0) {
       showToast("no similar conversations yet (semantic layout may still be warming)");
@@ -739,10 +750,25 @@ export async function runApp(): Promise<void> {
       const cwd = t?.cwd ? t.cwd.split("/").pop() ?? "" : "";
       return `${scoreBar(h.score)} \x1b[36m${name}\x1b[0m \x1b[${MUTED}m${cwd}\x1b[0m`;
     });
+    // The receipts: each hit's top matching chunk pairs, shown for the
+    // selected row. ⚙ marks a match coming from tool activity (same files)
+    // rather than conversation topic — worth knowing which kind of similar.
+    const detail = hits.map((h) =>
+      h.evidence?.map((e) => {
+        const tools = e.kindA === "tools" && e.kindB === "tools";
+        const mark = tools ? "⚙ " : "";
+        const room = 30;
+        return (
+          `\x1b[${MUTED}m${mark}“${truncateStr(e.a, room)}” ↔ “${truncateStr(e.b, room)}”` +
+          ` · ${e.score.toFixed(2)}\x1b[0m`
+        );
+      }),
+    );
     overlay = {
       kind: "menu",
       title: `similar to ${anchor ? treeTitle(anchor).title : treeId}`,
       options,
+      detail,
       selected: 0,
       onPick: (i) => {
         const hit = hits[i];

--- a/src/daemon/chunksim.ts
+++ b/src/daemon/chunksim.ts
@@ -1,0 +1,191 @@
+/**
+ * Chunk-set similarity: compare two trees by MATCHING their essence chunks
+ * instead of comparing one blended vector per tree.
+ *
+ * Pooling averages a session into a single point, which erases sub-topics: a
+ * conversation that is half auth and half parser lands *between* the two
+ * clusters, similar to nothing. Matching chunk sets fixes that — each side's
+ * chunks find their best counterpart on the other side (a weighted symmetric
+ * Chamfer score, ColBERT-style late interaction) — and it makes every score
+ * explainable for free: the top contributing pairs ARE the receipts.
+ *
+ * Used as stage 2 of the `similar` request: the pooled cosine (cheap, whole
+ * forest) shortlists candidates; this re-ranks them and attaches evidence.
+ * The pooled vector keeps its other job (map layout) untouched.
+ */
+import {
+  chunksForTree,
+  similarTrees,
+  vectorOf,
+  type DB,
+} from "../store/db.js";
+import { selectChunkWindow, weighChunks } from "./essence.js";
+import type { SimilarEvidence, SimilarHit } from "../shared/types.js";
+
+export interface WeightedChunk {
+  key: string;
+  kind: string;
+  weight: number;
+  vec: Float32Array;
+}
+
+/**
+ * A tree's scorable chunk set: the cached rows, narrowed to the same pooling
+ * window and weighed by the same importance formula the pooled vector uses.
+ * Empty when the tree never embedded (model cold / lexical-only).
+ */
+export function weighedWindow(db: DB, treeId: string): WeightedChunk[] {
+  const rows = selectChunkWindow(chunksForTree(db, treeId));
+  return weighChunks(rows.map((r) => ({ kind: r.kind, pos: r.pos, row: r }))).map(
+    ({ chunk, weight }) => ({
+      key: chunk.row.chunk_key,
+      kind: chunk.kind,
+      weight,
+      vec: vectorOf(chunk.row.embedding),
+    }),
+  );
+}
+
+export interface ChunkMatch {
+  aKey: string;
+  bKey: string;
+  aKind: string;
+  bKind: string;
+  /** Raw cosine of the pair. */
+  score: number;
+  /** score × mean pair weight — what the pair contributed to the ranking. */
+  contribution: number;
+}
+
+export interface ChunkSimResult {
+  /** Weighted symmetric Chamfer score, in cosine's [-1, 1] range. */
+  score: number;
+  /** Top contributing pairs, by contribution, deduped. */
+  matches: ChunkMatch[];
+}
+
+/**
+ * Weighted symmetric Chamfer: each chunk of A meets its best match in B
+ * (weighted mean over A), and vice versa; the score is the mean of the two
+ * directions. Weights are normalized per side, so the result stays in
+ * cosine's range and a low-weight tail can't drown the signal.
+ */
+export function chunkSimilarity(
+  a: WeightedChunk[],
+  b: WeightedChunk[],
+  topK = 3,
+): ChunkSimResult | null {
+  if (a.length === 0 || b.length === 0) return null;
+  const dim = a[0]!.vec.length;
+  const bSame = b.filter((c) => c.vec.length === dim);
+  if (bSame.length === 0) return null; // stale vectors from another model
+
+  const pairs = new Map<string, ChunkMatch>();
+  const note = (x: WeightedChunk, y: WeightedChunk, cos: number, flipped: boolean) => {
+    const [ac, bc] = flipped ? [y, x] : [x, y];
+    const key = `${ac.key}|${bc.key}`;
+    if (pairs.has(key)) return;
+    pairs.set(key, {
+      aKey: ac.key,
+      bKey: bc.key,
+      aKind: ac.kind,
+      bKind: bc.kind,
+      score: cos,
+      contribution: cos * ((ac.weight + bc.weight) / 2),
+    });
+  };
+
+  const direction = (from: WeightedChunk[], to: WeightedChunk[], flipped: boolean): number => {
+    let acc = 0;
+    let wSum = 0;
+    for (const c of from) {
+      let best = -Infinity;
+      let bestTo: WeightedChunk | undefined;
+      for (const t of to) {
+        let dot = 0;
+        for (let i = 0; i < dim; i++) dot += c.vec[i]! * t.vec[i]!;
+        if (dot > best) {
+          best = dot;
+          bestTo = t;
+        }
+      }
+      if (!bestTo) continue;
+      acc += best * c.weight;
+      wSum += c.weight;
+      note(c, bestTo, best, flipped);
+    }
+    return wSum > 0 ? acc / wSum : 0;
+  };
+
+  const aSame = a.filter((c) => c.vec.length === dim);
+  const score = (direction(aSame, bSame, false) + direction(bSame, aSame, true)) / 2;
+  const matches = [...pairs.values()]
+    .sort((x, y) => y.contribution - x.contribution)
+    .slice(0, topK);
+  return { score, matches };
+}
+
+/** Stage-1 shortlist size: cheap pooled cosine narrows the field to this. */
+const CANDIDATES = 32;
+/**
+ * Stage-1 floor, deliberately BELOW the final 0.25: pooled vectors under-score
+ * exactly the multi-topic sessions stage 2 exists to catch — a strict stage-1
+ * floor would filter them before the honest scorer ever saw them.
+ */
+const STAGE1_FLOOR = 0.1;
+/** Final floor, same bar the pooled-only ranking used. */
+const MIN_SCORE = 0.25;
+
+/** Resolve a chunk key to a display excerpt (undefined = drop the pair). */
+export type ChunkTextResolver = (
+  treeId: string,
+  chunkKey: string,
+) => Promise<string | undefined>;
+
+/**
+ * The `similar` ranking: pooled shortlist → chunk-set re-rank → evidence.
+ * Candidates without cached chunks keep their stage-1 pooled score with no
+ * evidence (the model may be cold) — `s` degrades, never goes blank.
+ */
+export async function rankSimilar(
+  db: DB,
+  treeId: string,
+  opts: { k?: number; resolveText?: ChunkTextResolver } = {},
+): Promise<SimilarHit[]> {
+  const k = opts.k ?? 8;
+  const shortlist = similarTrees(db, treeId, CANDIDATES, STAGE1_FLOOR);
+  if (shortlist.length === 0) return [];
+
+  const anchor = weighedWindow(db, treeId);
+  const scored: Array<{ treeId: string; score: number; matches: ChunkMatch[] }> = [];
+  for (const cand of shortlist) {
+    const theirs = anchor.length > 0 ? weighedWindow(db, cand.tree_id) : [];
+    const sim = anchor.length > 0 ? chunkSimilarity(anchor, theirs) : null;
+    if (sim) scored.push({ treeId: cand.tree_id, score: sim.score, matches: sim.matches });
+    else if (cand.score >= MIN_SCORE) {
+      // No chunk sets to match (cold model, chunkless tree): the pooled
+      // score is still an honest cosine — keep it, without receipts.
+      scored.push({ treeId: cand.tree_id, score: cand.score, matches: [] });
+    }
+  }
+  scored.sort((x, y) => y.score - x.score);
+  const top = scored.filter((s) => s.score >= MIN_SCORE).slice(0, k);
+
+  const hits: SimilarHit[] = [];
+  for (const s of top) {
+    let evidence: SimilarEvidence[] | undefined;
+    if (opts.resolveText && s.matches.length > 0) {
+      evidence = [];
+      for (const m of s.matches) {
+        const a = await opts.resolveText(treeId, m.aKey);
+        const b = await opts.resolveText(s.treeId, m.bKey);
+        // A pruned or vanished chunk has no text to show — drop the pair
+        // rather than presenting an id as an explanation.
+        if (a && b) evidence.push({ a, b, kindA: m.aKind, kindB: m.bKind, score: m.score });
+      }
+      if (evidence.length === 0) evidence = undefined;
+    }
+    hits.push({ treeId: s.treeId, score: s.score, ...(evidence ? { evidence } : {}) });
+  }
+  return hits;
+}

--- a/src/daemon/chunksim.ts
+++ b/src/daemon/chunksim.ts
@@ -163,8 +163,13 @@ export async function rankSimilar(
     const sim = anchor.length > 0 ? chunkSimilarity(anchor, theirs) : null;
     if (sim) scored.push({ treeId: cand.tree_id, score: sim.score, matches: sim.matches });
     else if (cand.score >= MIN_SCORE) {
-      // No chunk sets to match (cold model, chunkless tree): the pooled
-      // score is still an honest cosine — keep it, without receipts.
+      // DEFENSIVE, not an expected path: repool only writes trees.embedding
+      // from chunk rows, so a shortlisted tree should always have a scorable
+      // window — this fires only for stores mutated outside that invariant
+      // (hand-edited DB, partial prune). The pooled score is still an honest
+      // cosine — keep it, without receipts, rather than going blank. If this
+      // ever becomes a live path, mind the two score scales sharing one
+      // ranking: Chamfer runs hotter than pooled cosine.
       scored.push({ treeId: cand.tree_id, score: cand.score, matches: [] });
     }
   }

--- a/src/daemon/essence.ts
+++ b/src/daemon/essence.ts
@@ -163,6 +163,58 @@ const META_WEIGHT = 1.0;
 const TOOLS_WEIGHT = 0.6;
 
 /**
+ * The pooling window over CACHED chunk rows: newest user messages plus the
+ * first, newest summaries, and the digests. The cache deliberately keeps
+ * more user rows than the window (so a scrolled-out chunk isn't churned);
+ * everything that CONSUMES the cache — pooling and chunk-set similarity —
+ * must select through this one function or the two drift apart.
+ * `rows` must be in pos order (chunksForTree's order).
+ */
+export function selectChunkWindow<T extends { kind: string; chunk_key: string }>(rows: T[]): T[] {
+  const users = rows.filter((r) => r.kind === "user");
+  const userWindow = new Set(
+    users
+      .slice(-MAX_USER_CHUNKS)
+      .concat(users.length > 0 ? [users[0]!] : [])
+      .map((r) => r.chunk_key),
+  );
+  const summaries = rows.filter((r) => r.kind === "summary");
+  const summaryWindow = new Set(summaries.slice(-MAX_SUMMARY_CHUNKS).map((r) => r.chunk_key));
+  return rows.filter(
+    (r) =>
+      r.kind === "meta" ||
+      r.kind === "tools" ||
+      (r.kind === "user" && userWindow.has(r.chunk_key)) ||
+      (r.kind === "summary" && summaryWindow.has(r.chunk_key)),
+  );
+}
+
+/**
+ * One notion of chunk importance, shared by pooling and chunk-set similarity:
+ * users decay by recency with a floor for the opener, summaries decay from
+ * 0.9, meta counts fully, the tools digest 0.6.
+ */
+export function weighChunks<T extends { kind: string; pos: number }>(
+  chunks: T[],
+): Array<{ chunk: T; weight: number }> {
+  const users = chunks.filter((c) => c.kind === "user").sort((a, b) => a.pos - b.pos);
+  const summaries = chunks.filter((c) => c.kind === "summary").sort((a, b) => a.pos - b.pos);
+  const weights = new Map<T, number>();
+  users.forEach((c, i) => {
+    const recency = Math.pow(USER_DECAY, users.length - 1 - i);
+    weights.set(c, Math.max(recency, i === 0 ? FIRST_USER_FLOOR : USER_FLOOR));
+  });
+  summaries.forEach((c, j) => {
+    weights.set(c, SUMMARY_TOP * Math.pow(SUMMARY_DECAY, summaries.length - 1 - j));
+  });
+  for (const c of chunks) {
+    if (c.kind === "meta") weights.set(c, META_WEIGHT);
+    else if (c.kind === "tools") weights.set(c, TOOLS_WEIGHT);
+  }
+  return chunks.filter((c) => weights.has(c)).map((chunk) => ({ chunk, weight: weights.get(chunk)! }));
+}
+
+/**
  * Recency-weighted spherical mean of unit chunk vectors → unit tree vector.
  * Returns null when there is nothing to pool (or the sum degenerates).
  */
@@ -172,25 +224,9 @@ export function poolChunks(
   if (chunks.length === 0) return null;
   const dim = chunks[0]!.vec.length;
   const sum = new Float32Array(dim);
-
-  const users = chunks.filter((c) => c.kind === "user").sort((a, b) => a.pos - b.pos);
-  const summaries = chunks.filter((c) => c.kind === "summary").sort((a, b) => a.pos - b.pos);
-
-  const add = (vec: Float32Array, w: number) => {
-    for (let i = 0; i < dim; i++) sum[i]! += vec[i]! * w;
-  };
-  users.forEach((c, i) => {
-    const recency = Math.pow(USER_DECAY, users.length - 1 - i);
-    add(c.vec, Math.max(recency, i === 0 ? FIRST_USER_FLOOR : USER_FLOOR));
-  });
-  summaries.forEach((c, j) => {
-    add(c.vec, SUMMARY_TOP * Math.pow(SUMMARY_DECAY, summaries.length - 1 - j));
-  });
-  for (const c of chunks) {
-    if (c.kind === "meta") add(c.vec, META_WEIGHT);
-    else if (c.kind === "tools") add(c.vec, TOOLS_WEIGHT);
+  for (const { chunk, weight } of weighChunks(chunks)) {
+    for (let i = 0; i < dim; i++) sum[i]! += chunk.vec[i]! * weight;
   }
-
   let norm = 0;
   for (let i = 0; i < dim; i++) norm += sum[i]! * sum[i]!;
   norm = Math.sqrt(norm);

--- a/src/daemon/semantic.ts
+++ b/src/daemon/semantic.ts
@@ -27,9 +27,8 @@ import { DEFAULT_EMBED_MODEL, loadConfig } from "../shared/config.js";
 import {
   essenceChunks,
   poolChunks,
+  selectChunkWindow,
   validChunkKeys,
-  MAX_SUMMARY_CHUNKS,
-  MAX_USER_CHUNKS,
   USER_CHUNK_CACHE,
   type EssenceChunk,
 } from "./essence.js";
@@ -248,25 +247,8 @@ export class SemanticLayout {
    */
   private repool(treeId: string): void {
     const rows = chunksForTree(this.deps.db, treeId);
-    const users = rows.filter((r) => r.kind === "user");
-    const userWindow = new Set(
-      users
-        .slice(-MAX_USER_CHUNKS)
-        .concat(users.length > 0 ? [users[0]!] : [])
-        .map((r) => r.chunk_key),
-    );
-    const summaries = rows.filter((r) => r.kind === "summary");
-    const summaryWindow = new Set(summaries.slice(-MAX_SUMMARY_CHUNKS).map((r) => r.chunk_key));
     const pooled = poolChunks(
-      rows
-        .filter(
-          (r) =>
-            r.kind === "meta" ||
-            r.kind === "tools" ||
-            (r.kind === "user" && userWindow.has(r.chunk_key)) ||
-            (r.kind === "summary" && summaryWindow.has(r.chunk_key)),
-        )
-        .map((r) => ({ kind: r.kind, pos: r.pos, vec: vectorOf(r.embedding) })),
+      selectChunkWindow(rows).map((r) => ({ kind: r.kind, pos: r.pos, vec: vectorOf(r.embedding) })),
     );
     if (!pooled) {
       this.settleBackfill(treeId);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -824,28 +824,44 @@ export class Daemon {
     // matching re-ranks and explains. A tree with no embedding yet is not an
     // error — the model may still be warming (or unavailable); the client
     // renders the empty list accordingly.
+    //
+    // Excerpt lookups memoize PER REQUEST: one essenceChunks pass per tree,
+    // where per-lookup resolution would rebuild the identical chunk list
+    // dozens of times per keypress (half of them for the anchor alone).
+    const memo = new Map<string, Promise<Map<string, string> | undefined>>();
+    const textsOf = (treeId: string): Promise<Map<string, string> | undefined> => {
+      let p = memo.get(treeId);
+      if (!p) {
+        p = this.chunkTexts(treeId);
+        memo.set(treeId, p);
+      }
+      return p;
+    };
     const similar = await rankSimilar(this.db, msg.treeId, {
       k: msg.k ?? 8,
-      resolveText: (treeId, chunkKey) => this.chunkText(treeId, chunkKey),
+      resolveText: async (treeId, chunkKey) => (await textsOf(treeId))?.get(chunkKey),
     });
     client.wire.send({ t: "result", re: msg.id, ok: true, similar });
   }
 
   /**
-   * Display excerpt for a chunk key, resolved from the session file (through
-   * the parse cache) rather than stored — text that cannot go stale. Keys are
-   * entry ids (user messages, summaries) or content-hashed digest keys, and
-   * essenceChunks rebuilds exactly the texts those keys were minted from.
+   * Display excerpts for a tree's chunks, resolved from the session file
+   * (through the parse cache) rather than stored — text that cannot go
+   * stale. Keys are entry ids (user messages, summaries) or content-hashed
+   * digest keys, and essenceChunks rebuilds exactly the texts those keys
+   * were minted from.
    */
-  private async chunkText(treeId: string, chunkKey: string): Promise<string | undefined> {
+  private async chunkTexts(treeId: string): Promise<Map<string, string> | undefined> {
     const rec = this.supervisor.trees.get(treeId);
     if (!rec?.sessionPath || !existsSync(rec.sessionPath)) return undefined;
     try {
       const parsed = await parseSessionFile(rec.sessionPath);
-      const chunk = essenceChunks(rec.name ?? parsed.name, parsed).find((c) => c.key === chunkKey);
-      if (!chunk) return undefined;
-      const text = chunk.text.replace(/\s+/g, " ").trim();
-      return text.length > 90 ? text.slice(0, 89) + "…" : text;
+      const texts = new Map<string, string>();
+      for (const chunk of essenceChunks(rec.name ?? parsed.name, parsed)) {
+        const text = chunk.text.replace(/\s+/g, " ").trim();
+        texts.set(chunk.key, text.length > 90 ? text.slice(0, 89) + "…" : text);
+      }
+      return texts;
     } catch {
       return undefined;
     }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -75,8 +75,10 @@ function deriveTreeName(parsed: ParsedSession): string | null {
 import { relax } from "../layout/relax.js";
 import { branchInPlace, branchToNewTree, setNodeLabel, type BranchDeps } from "./branch.js";
 import { SemanticLayout } from "./semantic.js";
-import { searchFts, similarTrees } from "../store/db.js";
-import type { SearchHit, SimilarHit, TreeStatus } from "../shared/types.js";
+import { searchFts } from "../store/db.js";
+import { rankSimilar } from "./chunksim.js";
+import { essenceChunks } from "./essence.js";
+import type { SearchHit, TreeStatus } from "../shared/types.js";
 
 /** How long a version-rejected connection stays open to accept `shutdown`. */
 const REJECTED_GRACE_MS = 2000;
@@ -818,11 +820,35 @@ export class Daemon {
   }
 
   protected async handleSimilar(client: ClientConn, msg: SimilarMsg): Promise<void> {
-    // A tree with no embedding yet is not an error — the model may still be
-    // warming (or unavailable); the client renders the empty list accordingly.
-    const rows = similarTrees(this.db, msg.treeId, msg.k ?? 8);
-    const similar: SimilarHit[] = rows.map((r) => ({ treeId: r.tree_id, score: r.score }));
+    // Two-stage: pooled cosine shortlists (cheap, whole forest), chunk-set
+    // matching re-ranks and explains. A tree with no embedding yet is not an
+    // error — the model may still be warming (or unavailable); the client
+    // renders the empty list accordingly.
+    const similar = await rankSimilar(this.db, msg.treeId, {
+      k: msg.k ?? 8,
+      resolveText: (treeId, chunkKey) => this.chunkText(treeId, chunkKey),
+    });
     client.wire.send({ t: "result", re: msg.id, ok: true, similar });
+  }
+
+  /**
+   * Display excerpt for a chunk key, resolved from the session file (through
+   * the parse cache) rather than stored — text that cannot go stale. Keys are
+   * entry ids (user messages, summaries) or content-hashed digest keys, and
+   * essenceChunks rebuilds exactly the texts those keys were minted from.
+   */
+  private async chunkText(treeId: string, chunkKey: string): Promise<string | undefined> {
+    const rec = this.supervisor.trees.get(treeId);
+    if (!rec?.sessionPath || !existsSync(rec.sessionPath)) return undefined;
+    try {
+      const parsed = await parseSessionFile(rec.sessionPath);
+      const chunk = essenceChunks(rec.name ?? parsed.name, parsed).find((c) => c.key === chunkKey);
+      if (!chunk) return undefined;
+      const text = chunk.text.replace(/\s+/g, " ").trim();
+      return text.length > 90 ? text.slice(0, 89) + "…" : text;
+    } catch {
+      return undefined;
+    }
   }
 
   protected async handleSetLabel(client: ClientConn, msg: SetLabelMsg): Promise<void> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -65,11 +65,28 @@ export interface SearchHit {
   rank: number;
 }
 
-/** One neighbor from a "similar trees" query (cosine over pooled embeddings). */
+/** One matching chunk pair backing a similarity score — the receipt. */
+export interface SimilarEvidence {
+  /** Excerpt from the anchor tree (pre-clipped daemon-side). */
+  a: string;
+  /** Excerpt from the neighbor. */
+  b: string;
+  kindA: string;
+  kindB: string;
+  /** Cosine of this pair. */
+  score: number;
+}
+
+/**
+ * One neighbor from a "similar trees" query. The score is a chunk-matched
+ * (late-interaction) similarity when chunk vectors exist, else the pooled
+ * cosine; both live in [-1, 1] with a ~0.25 floor. Evidence, when present,
+ * lists the top matching chunk pairs behind the score.
+ */
 export interface SimilarHit {
   treeId: string;
-  /** Cosine similarity in [-1, 1]; in practice the floor is ~0.25. */
   score: number;
+  evidence?: SimilarEvidence[];
 }
 
 export interface Camera {

--- a/test/chunksim.test.ts
+++ b/test/chunksim.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Chunk-set similarity: weighted symmetric Chamfer over cached chunk vectors,
+ * two-stage ranking, and evidence. The headline behavior: a multi-topic
+ * session matches BOTH of its topics' trees — the case pooled averaging
+ * structurally cannot get right, because its blended vector sits between the
+ * clusters, near neither.
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chunkSimilarity, rankSimilar, weighedWindow, type WeightedChunk } from "../src/daemon/chunksim.js";
+import { poolChunks } from "../src/daemon/essence.js";
+import { openDb, upsertChunks, upsertTree } from "../src/store/db.js";
+
+const DIM = 8;
+
+function axis(i: number): Float32Array {
+  const v = new Float32Array(DIM);
+  v[i] = 1;
+  return v;
+}
+
+function wc(key: string, kind: string, weight: number, vec: Float32Array): WeightedChunk {
+  return { key, kind, weight, vec };
+}
+
+describe("chunkSimilarity", () => {
+  it("scores identical sets at 1 and orthogonal sets at 0, staying in cosine range", () => {
+    const a = [wc("a1", "user", 1, axis(0)), wc("a2", "user", 0.85, axis(1))];
+    const same = chunkSimilarity(a, a)!;
+    expect(same.score).toBeCloseTo(1, 5);
+    const b = [wc("b1", "user", 1, axis(4)), wc("b2", "user", 0.85, axis(5))];
+    const cross = chunkSimilarity(a, b)!;
+    expect(cross.score).toBeCloseTo(0, 5);
+  });
+
+  it("a mixed-topic set matches a pure set far better than their pooled vectors do", () => {
+    const pureX = [wc("x1", "user", 0.85, axis(0)), wc("x2", "user", 1, axis(0))];
+    const mixed = [wc("mx", "user", 1, axis(0)), wc("my", "user", 1, axis(4))];
+    const chunkScore = chunkSimilarity(mixed, pureX)!.score;
+    const pooledCos = (() => {
+      const p1 = poolChunks(pureX.map((c, i) => ({ kind: "user", pos: i, vec: c.vec })))!;
+      const p2 = poolChunks(mixed.map((c, i) => ({ kind: "user", pos: i, vec: c.vec })))!;
+      let dot = 0;
+      for (let i = 0; i < DIM; i++) dot += p1[i]! * p2[i]!;
+      return dot;
+    })();
+    expect(chunkScore).toBeGreaterThan(pooledCos);
+    // From pureX's side every chunk finds a perfect match — the sub-topic is
+    // fully recognized even though half of `mixed` is about something else.
+    expect(chunkScore).toBeGreaterThan(0.7);
+  });
+
+  it("surfaces the top contributing pairs as evidence, weighted", () => {
+    const a = [wc("big", "user", 1, axis(0)), wc("small", "user", 0.05, axis(1))];
+    const b = [wc("bigB", "user", 1, axis(0)), wc("smallB", "user", 0.05, axis(1))];
+    const { matches } = chunkSimilarity(a, b)!;
+    // Both pairs match at cosine 1, but the heavy pair contributes more.
+    expect(matches[0]).toMatchObject({ aKey: "big", bKey: "bigB", score: 1 });
+    expect(matches.find((m) => m.aKey === "small")).toMatchObject({ bKey: "smallB" });
+  });
+
+  it("returns null for empty sets and for vectors from another model (dim mismatch)", () => {
+    const a = [wc("a", "user", 1, axis(0))];
+    expect(chunkSimilarity(a, [])).toBeNull();
+    expect(chunkSimilarity([], a)).toBeNull();
+    const other = [wc("o", "user", 1, new Float32Array(16))];
+    expect(chunkSimilarity(a, other)).toBeNull();
+  });
+});
+
+describe("rankSimilar (two-stage, on a real store)", () => {
+  function build() {
+    const db = openDb(join(mkdtempSync(join(tmpdir(), "pines-chunksim-")), "pines.db"));
+    const add = (id: string, chunks: Array<{ key: string; kind: string; pos: number; vec: Float32Array }>) => {
+      upsertTree(db, { tree_id: id, session_path: `/s/${id}.jsonl` });
+      if (chunks.length > 0) {
+        upsertChunks(
+          db,
+          id,
+          chunks.map((c) => ({ chunkKey: c.key, kind: c.kind, pos: c.pos, embedding: Buffer.from(c.vec.buffer) })),
+        );
+        const pooled = poolChunks(chunks.map((c) => ({ kind: c.kind, pos: c.pos, vec: c.vec })))!;
+        db.prepare("UPDATE trees SET embedding = ? WHERE tree_id = ?").run(Buffer.from(pooled.buffer), id);
+      }
+    };
+    return { db, add };
+  }
+
+  it("ranks by chunk match, attaches resolved evidence, keeps chunkless trees pooled", async () => {
+    const { db, add } = build();
+    add("t_anchor", [
+      { key: "a_x", kind: "user", pos: 0, vec: axis(0) },
+      { key: "a_x2", kind: "user", pos: 1, vec: axis(0) },
+    ]);
+    add("t_sameTopic", [
+      { key: "s_x", kind: "user", pos: 0, vec: axis(0) },
+    ]);
+    add("t_offTopic", [{ key: "o_y", kind: "user", pos: 0, vec: axis(4) }]);
+    // Chunkless but with a pooled embedding on the anchor's topic (e.g. a
+    // tree embedded by an older version whose chunks were wiped).
+    upsertTree(db, { tree_id: "t_pooledOnly", session_path: "/s/p.jsonl" });
+    db.prepare("UPDATE trees SET embedding = ? WHERE tree_id = ?").run(
+      Buffer.from(axis(0).buffer),
+      "t_pooledOnly",
+    );
+
+    const hits = await rankSimilar(db, "t_anchor", {
+      resolveText: async (treeId, key) => `${treeId}:${key}`,
+    });
+    const ids = hits.map((h) => h.treeId);
+    expect(ids).toContain("t_sameTopic");
+    expect(ids).toContain("t_pooledOnly");
+    expect(ids).not.toContain("t_offTopic"); // orthogonal: below every floor
+    expect(ids).not.toContain("t_anchor");
+
+    const same = hits.find((h) => h.treeId === "t_sameTopic")!;
+    expect(same.score).toBeCloseTo(1, 5);
+    // Top receipt = highest contribution = the NEWER (heavier) anchor chunk.
+    expect(same.evidence![0]).toMatchObject({
+      a: "t_anchor:a_x2",
+      b: "t_sameTopic:s_x",
+      kindA: "user",
+      kindB: "user",
+    });
+    // The pooled-only hit is honest but receipt-less.
+    expect(hits.find((h) => h.treeId === "t_pooledOnly")!.evidence).toBeUndefined();
+    db.close();
+  });
+
+  it("rescues a multi-topic neighbor the pooled floor would have dropped", async () => {
+    const { db, add } = build();
+    add("t_anchor", [
+      { key: "a_x", kind: "user", pos: 0, vec: axis(0) },
+      { key: "a_x2", kind: "user", pos: 1, vec: axis(0) },
+    ]);
+    // One old X turn buried under three newer Y turns: pooled cosine with the
+    // anchor lands ~0.23 — under the 0.25 floor the old ranking applied.
+    add("t_mixed", [
+      { key: "m_x", kind: "user", pos: 0, vec: axis(0) },
+      { key: "m_y1", kind: "user", pos: 1, vec: axis(4) },
+      { key: "m_y2", kind: "user", pos: 2, vec: axis(4) },
+      { key: "m_y3", kind: "user", pos: 3, vec: axis(4) },
+    ]);
+
+    const hits = await rankSimilar(db, "t_anchor", {});
+    const mixed = hits.find((h) => h.treeId === "t_mixed");
+    expect(mixed).toBeDefined();
+    expect(mixed!.score).toBeGreaterThan(0.25);
+    db.close();
+  });
+
+  it("weighedWindow applies the pooling window and weights to cached rows", () => {
+    const { db, add } = build();
+    add("t_w", [
+      { key: "meta:m", kind: "meta", pos: -1, vec: axis(2) },
+      { key: "u0", kind: "user", pos: 0, vec: axis(0) },
+      { key: "u1", kind: "user", pos: 1, vec: axis(1) },
+    ]);
+    const set = weighedWindow(db, "t_w");
+    const byKey = new Map(set.map((c) => [c.key, c]));
+    expect(byKey.get("meta:m")!.weight).toBe(1);
+    expect(byKey.get("u1")!.weight).toBe(1); // newest user
+    expect(byKey.get("u0")!.weight).toBeCloseTo(0.85, 5); // one step back
+    expect(weighedWindow(db, "t_missing")).toEqual([]);
+    db.close();
+  });
+});


### PR DESCRIPTION
Implements the plan discussed after the "why are these trees near each other?" question. The `s` ranking stops comparing one blended vector per tree and starts **matching the trees' chunk sets** — which fixes pooling's structural blind spot and makes every score explainable, from data already on disk.

## How it works

- **Stage 1 (unchanged math):** pooled cosine over the whole forest shortlists ~32 candidates. Its floor is deliberately lowered to 0.1 here — pooled vectors *under-score exactly the multi-topic sessions stage 2 exists to catch*, so a strict stage-1 floor would filter them before the honest scorer saw them.
- **Stage 2:** weighted symmetric Chamfer (ColBERT-style late interaction) over the cached per-chunk vectors in `tree_chunks`: each side's chunks find their best counterpart on the other side, weighed by the *same* recency/kind formula the pooled vector uses. That formula and the pooling-window selection are now extracted into shared `weighChunks` / `selectChunkWindow` (used by both `poolChunks`/`repool` and the scorer), so the two notions of importance can never drift.
- **Evidence:** the top contributing pairs ride along on each `SimilarHit` (additive optional protocol field, no version bump). Excerpts are resolved at query time from the session JSONL through the parse cache — never stored, cannot go stale; unresolvable (pruned) chunks drop their pair rather than presenting an id as an explanation.
- **Degradation:** trees with no cached chunks (cold model, older embeds) keep their stage-1 pooled score with no receipts — `s` degrades, never goes blank.
- **Client:** the `s` overlay shows the selected hit's receipts under the list — `“fix oauth refresh” ↔ “login returns 401” · 0.71` — with `⚙` marking matches that come from tool activity (same files) rather than topic.

## What deliberately didn't change

- **No schema migration** (`SCHEMA_VERSION` stays 3) — everything the scorer needs was already persisted.
- **No `EMBED_VERSION` bump** — chunking is untouched, so no re-embed storm on upgrade; existing caches are valid as-is.
- **The map is untouched** — pooled vector + stable PCA projection keep doing layout. `GUIDE.md` now states the split honestly: the map is the approximate view, the `s` list the honest one.

## Tests

New `test/chunksim.test.ts` (8 tests): identical/orthogonal bounds, **mixed-topic set scores far above its pooled cosine against a pure set** (the headline fix), weighted evidence ordering, dim-mismatch null, and `rankSimilar` against a real store — including the rescue case: a neighbor whose pooled cosine (~0.23) fell under the old 0.25 floor but chunk-matches at ~0.6, and the chunkless-tree fallback. This doubles as the eval anchor the weights never had. Suite: 31 files / **161 tests green**, `tsc` clean.

Bumps to **0.1.5** — merging releases it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QuVLfbJnrCTPHCmyqsqTh

---
_Generated by [Claude Code](https://claude.ai/code/session_019QuVLfbJnrCTPHCmyqsqTh)_