### PR TITLE
v0.1.8: attention notifications when an agent finishes off-screen

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -234,8 +234,11 @@ projected to 2-D for stability); the `s` list is the honest one.
 ```
 
 `notify` rings when an agent finishes, needs input, or crashes while you
-aren't watching it — the terminal is unfocused, or a different agent's pi
-covers the screen. Modes:
+aren't watching it — the terminal is unfocused, focus is unknowable (a
+terminal without focus reporting, e.g. Apple Terminal, or tmux without
+`set -g focus-events on`), or a different agent's pi covers the screen. Only
+a provably focused terminal showing the forest/tree views (or that agent's
+own pi) stays quiet. Modes:
 
 - `"terminal"` (default) — desktop toast via OSC escape codes (kitty, iTerm2,
   WezTerm, Ghostty, foot, Warp); other terminals get a plain BEL. Works over

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -227,6 +227,7 @@ projected to 2-D for stability); the `s` list is the honest one.
   "prefixKey": "ctrl+t",
   "boot": "off",
   "notify": "terminal",
+  "notifySound": "Submarine",
   "maxLiveAgents": 12,
   "piBin": "/path/to/custom/pi",
   "embedModel": "Xenova/bge-small-en-v1.5"
@@ -250,6 +251,12 @@ own pi) stays quiet. Modes:
 - `"system"` — OS notifier (`osascript` on macOS, `notify-send` on Linux):
   works in any terminal, but not over SSH.
 - `"off"` — silence.
+
+`notifySound` picks the sound instead of the BEL (or the system notifier's
+default): a macOS system sound name — `Submarine`, `Ping`, `Hero`, `Glass`,
+anything in `/System/Library/Sounds` — or a path to an audio file. Played via
+`afplay` (macOS) / `paplay` (Linux), so unlike the BEL it doesn't depend on
+the terminal's bell settings.
 
 `maxLiveAgents` caps concurrent pi processes (default 12). The slots are a
 warm cache of instantly-attachable sessions — kept full on purpose. When a

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -226,11 +226,25 @@ projected to 2-D for stability); the `s` list is the honest one.
 {
   "prefixKey": "ctrl+t",
   "boot": "off",
+  "notify": "terminal",
   "maxLiveAgents": 12,
   "piBin": "/path/to/custom/pi",
   "embedModel": "Xenova/bge-small-en-v1.5"
 }
 ```
+
+`notify` rings when an agent finishes, needs input, or crashes while you
+aren't watching it — the terminal is unfocused, or a different agent's pi
+covers the screen. Modes:
+
+- `"terminal"` (default) — desktop toast via OSC escape codes (kitty, iTerm2,
+  WezTerm, Ghostty, foot, Warp); other terminals get a plain BEL. Works over
+  SSH. Inside tmux the toast needs `set -g allow-passthrough on` (tmux ≥ 3.3);
+  the BEL fallback pairs well with tmux's `monitor-bell` window flags.
+- `"bell"` — BEL only.
+- `"system"` — OS notifier (`osascript` on macOS, `notify-send` on Linux):
+  works in any terminal, but not over SSH.
+- `"off"` — silence.
 
 `maxLiveAgents` caps concurrent pi processes (default 12). The slots are a
 warm cache of instantly-attachable sessions — kept full on purpose. When a

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -256,7 +256,8 @@ own pi) stays quiet. Modes:
 default): a macOS system sound name — `Submarine`, `Ping`, `Hero`, `Glass`,
 anything in `/System/Library/Sounds` — or a path to an audio file. Played via
 `afplay` (macOS) / `paplay` (Linux), so unlike the BEL it doesn't depend on
-the terminal's bell settings.
+the terminal's bell settings. Defaults to `Hero` on macOS (elsewhere the BEL
+is the default); set it to `""` for the plain BEL.
 
 `maxLiveAgents` caps concurrent pi processes (default 12). The slots are a
 warm cache of instantly-attachable sessions — kept full on purpose. When a

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -240,10 +240,12 @@ terminal without focus reporting, e.g. Apple Terminal, or tmux without
 a provably focused terminal showing the forest/tree views (or that agent's
 own pi) stays quiet. Modes:
 
-- `"terminal"` (default) — desktop toast via OSC escape codes (kitty, iTerm2,
-  WezTerm, Ghostty, foot, Warp); other terminals get a plain BEL. Works over
-  SSH. Inside tmux the toast needs `set -g allow-passthrough on` (tmux ≥ 3.3);
-  the BEL fallback pairs well with tmux's `monitor-bell` window flags.
+- `"terminal"` (default) — BEL plus a desktop toast via OSC escape codes
+  (kitty, iTerm2, WezTerm, Ghostty, foot, Warp). The BEL rides along because
+  a toast can be swallowed silently (alert filtering, notification
+  permission, Focus mode) — hearing it needs your terminal's audible bell on.
+  Works over SSH. Inside tmux the toast needs `set -g allow-passthrough on`
+  (tmux ≥ 3.3); the BEL pairs well with tmux's `monitor-bell` window flags.
 - `"bell"` — BEL only.
 - `"system"` — OS notifier (`osascript` on macOS, `notify-send` on Linux):
   works in any terminal, but not over SSH.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edeng23/pines",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Tree-first orchestration TUI for pi coding agents. pi + trees = pines.",
   "license": "Apache-2.0",
   "author": "Eden Gaon",

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -88,7 +88,10 @@ import {
 import { renderConversation, convLayout, scrollTo } from "./tree/view.js";
 
 const NOTIFY_MODE: NotifyMode = loadConfig().notify ?? "terminal";
-const NOTIFY_SOUND = loadConfig().notifySound;
+// Default ding: Hero on macOS (afplay + system sounds are always there);
+// elsewhere the BEL remains the default. "" opts back into the plain BEL.
+const NOTIFY_SOUND =
+  loadConfig().notifySound ?? (process.platform === "darwin" ? "Hero" : undefined);
 
 const CONFIGURED_PREFIX = loadConfig().prefixKey;
 const PREFIX_KEY = (

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -56,6 +56,18 @@ import {
 } from "@earendil-works/pi-tui";
 
 import { loadConfig, prefixByte } from "../shared/config.js";
+import {
+  BELL,
+  buildToastSeq,
+  FOCUS_DISABLE,
+  FOCUS_ENABLE,
+  FOCUS_IN,
+  FOCUS_OUT,
+  shouldNotify,
+  systemNotify,
+  type FocusState,
+  type NotifyMode,
+} from "./notify.js";
 import { clipAnsi, visibleLength } from "./ansi.js";
 import { FAINT, MUTED } from "./theme.js";
 import {
@@ -73,6 +85,8 @@ import {
   familyOf,
 } from "./tree/merge.js";
 import { renderConversation, convLayout, scrollTo } from "./tree/view.js";
+
+const NOTIFY_MODE: NotifyMode = loadConfig().notify ?? "terminal";
 
 const CONFIGURED_PREFIX = loadConfig().prefixKey;
 const PREFIX_KEY = (
@@ -646,6 +660,41 @@ export async function runApp(): Promise<void> {
     setTimeout(() => requestRender(), 3100);
   }
 
+  /* --------------------------- attention notifying -------------------------- */
+
+  /** Terminal focus via CSI ?1004 — tri-state, never assumed when unknown. */
+  let termFocus: FocusState = "unknown";
+  /**
+   * Flap guard: extension-less agents demote to "waiting" on the PTY-quiet
+   * heuristic and can bounce back to "running" mid-task; don't ring on every
+   * bounce.
+   */
+  const lastNotifiedAt = new Map<string, number>();
+  const NOTIFY_COOLDOWN_MS = 30_000;
+
+  /** An agent stopped working (waiting/completed/crashed): tell the user. */
+  function notifyAttention(t: TreeSummary): void {
+    if (NOTIFY_MODE === "off") return;
+    const attachedTreeId = mode.kind === "attached" ? mode.treeId : null;
+    if (!shouldNotify(termFocus, { treeId: t.treeId, attachedTreeId })) return;
+    const now = Date.now();
+    if (now - (lastNotifiedAt.get(t.treeId) ?? 0) < NOTIFY_COOLDOWN_MS) return;
+    lastNotifiedAt.set(t.treeId, now);
+    const verb =
+      t.status === "crashed"
+        ? "crashed"
+        : t.status === "completed"
+          ? "completed"
+          : "finished — waiting for you";
+    const body = `${treeTitle(t).title} ${verb}`;
+    if (NOTIFY_MODE === "system") return systemNotify("pines", body);
+    if (NOTIFY_MODE === "bell") {
+      out.write(BELL);
+      return;
+    }
+    out.write(buildToastSeq("pines", body) ?? BELL);
+  }
+
   /* ----------------------------- data fetching ----------------------------- */
 
   /**
@@ -1192,7 +1241,8 @@ export async function runApp(): Promise<void> {
     if (mode.kind !== "attached") return;
     const treeId = mode.treeId;
     client.send({ t: "detach", treeId });
-    out.write("\x1b[r" + GUEST_INPUT_DISABLE + MOUSE_ENABLE); // reset scroll region
+    // Reset scroll region; re-assert focus reporting (pi may have reset it).
+    out.write("\x1b[r" + GUEST_INPUT_DISABLE + MOUSE_ENABLE + FOCUS_ENABLE);
     mode = { kind: "forest" };
     // Back out to the CONVERSATION, cursor on the branch we were just in.
     void openTree(treeId, forest.get(treeId)?.leafId ?? null);
@@ -1201,7 +1251,8 @@ export async function runApp(): Promise<void> {
   function detachToForest(): void {
     if (mode.kind !== "attached") return;
     client.send({ t: "detach", treeId: mode.treeId });
-    out.write("\x1b[r" + GUEST_INPUT_DISABLE + MOUSE_ENABLE); // reset scroll region
+    // Reset scroll region; re-assert focus reporting (pi may have reset it).
+    out.write("\x1b[r" + GUEST_INPUT_DISABLE + MOUSE_ENABLE + FOCUS_ENABLE);
     mode = { kind: "forest" };
     requestRender();
   }
@@ -1224,6 +1275,15 @@ export async function runApp(): Promise<void> {
       if (prev && prev.status !== "crashed" && t.status === "crashed") {
         const exit = t.lastExitCode != null ? ` (exit ${t.lastExitCode})` : "";
         showToast(`agent crashed: ${treeTitle(t).title}${exit} — see ~/.pines/daemon.log`);
+      }
+      // A working agent stopped (settled, exited, or crashed): ring/toast per
+      // the notify config unless the user is demonstrably already watching.
+      if (
+        prev &&
+        prev.status === "running" &&
+        (t.status === "waiting" || t.status === "completed" || t.status === "crashed")
+      ) {
+        notifyAttention(t);
       }
     }
     for (const id of remove ?? []) {
@@ -1298,7 +1358,7 @@ export async function runApp(): Promise<void> {
     clearInterval(spinnerTimer);
     stdin.setRawMode(false);
     stdin.pause();
-    out.write(GUEST_INPUT_DISABLE + MOUSE_DISABLE + ALT_SCREEN_LEAVE + "\x1b[0m");
+    out.write(GUEST_INPUT_DISABLE + MOUSE_DISABLE + FOCUS_DISABLE + ALT_SCREEN_LEAVE + "\x1b[0m");
   }
 
   function quit(): never {
@@ -1936,6 +1996,19 @@ export async function runApp(): Promise<void> {
 
   router.on("key", (key) => {
     void (async () => {
+      // Focus reporting (?1004): track it here, and pass it through to an
+      // attached pi — it may have asked the outer terminal for these itself.
+      if (key === FOCUS_IN || key === FOCUS_OUT) {
+        termFocus = key === FOCUS_IN ? "focused" : "blurred";
+        if (mode.kind === "attached") {
+          client.send({
+            t: "input",
+            treeId: mode.treeId,
+            data: Buffer.from(key, "utf8").toString("base64"),
+          });
+        }
+        return;
+      }
       if (mode.kind === "attached") {
         // Prefix interception; everything else passes through raw.
         const bytes = Buffer.from(key, "utf8");
@@ -2017,7 +2090,7 @@ export async function runApp(): Promise<void> {
     return n;
   });
 
-  out.write(ALT_SCREEN_ENTER + MOUSE_ENABLE);
+  out.write(ALT_SCREEN_ENTER + MOUSE_ENABLE + FOCUS_ENABLE);
   requestRender();
 }
 

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -692,7 +692,9 @@ export async function runApp(): Promise<void> {
       out.write(BELL);
       return;
     }
-    out.write(buildToastSeq("pines", body) ?? BELL);
+    // Toast AND bell: the toast can vanish silently (alert filtering, OS
+    // notification permission, Focus mode), so BEL backs it up audibly.
+    out.write(BELL + (buildToastSeq("pines", body) ?? ""));
   }
 
   /* ----------------------------- data fetching ----------------------------- */

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -63,6 +63,7 @@ import {
   FOCUS_ENABLE,
   FOCUS_IN,
   FOCUS_OUT,
+  playSound,
   shouldNotify,
   systemNotify,
   type FocusState,
@@ -87,6 +88,7 @@ import {
 import { renderConversation, convLayout, scrollTo } from "./tree/view.js";
 
 const NOTIFY_MODE: NotifyMode = loadConfig().notify ?? "terminal";
+const NOTIFY_SOUND = loadConfig().notifySound;
 
 const CONFIGURED_PREFIX = loadConfig().prefixKey;
 const PREFIX_KEY = (
@@ -687,14 +689,17 @@ export async function runApp(): Promise<void> {
           ? "completed"
           : "finished — waiting for you";
     const body = `${treeTitle(t).title} ${verb}`;
-    if (NOTIFY_MODE === "system") return systemNotify("pines", body);
+    // A configured notifySound replaces the BEL (and the system notifier's
+    // own sound) as the audible half of every mode.
+    if (NOTIFY_SOUND) playSound(NOTIFY_SOUND);
+    if (NOTIFY_MODE === "system") return systemNotify("pines", body, { mute: !!NOTIFY_SOUND });
     if (NOTIFY_MODE === "bell") {
-      out.write(BELL);
+      if (!NOTIFY_SOUND) out.write(BELL);
       return;
     }
     // Toast AND bell: the toast can vanish silently (alert filtering, OS
     // notification permission, Focus mode), so BEL backs it up audibly.
-    out.write(BELL + (buildToastSeq("pines", body) ?? ""));
+    out.write((NOTIFY_SOUND ? "" : BELL) + (buildToastSeq("pines", body) ?? ""));
   }
 
   /* ----------------------------- data fetching ----------------------------- */

--- a/src/client/notify.ts
+++ b/src/client/notify.ts
@@ -14,10 +14,10 @@
  *  - "off":      nothing.
  *
  * Suppression: the client tracks terminal focus via CSI ?1004 focus
- * reporting. A blurred terminal always notifies; a focused (or unknown-focus)
- * one notifies only when the finished tree is hidden behind a different
- * attached pi — forest/tree views already surface status changes themselves
- * (teal dot, crash toast).
+ * reporting. A known-focused terminal notifies only when the finished tree
+ * is hidden behind a different attached pi — forest/tree views already
+ * surface status changes themselves (teal dot, crash toast). Blurred, or
+ * unknown (a terminal that never reports focus), rings.
  */
 import { spawn } from "node:child_process";
 
@@ -77,16 +77,20 @@ export function buildToastSeq(
 }
 
 /**
- * Notify only when the user could have missed the event: terminal blurred,
- * or a *different* agent's pi is covering the screen. In forest/tree views
- * the status change is already visible in the UI.
+ * Suppress only when the user is provably looking: terminal known-focused on
+ * the forest/tree views (teal dot, crash toast) or on that very agent's pi.
+ * Unknown focus means a terminal without ?1004 support (Apple Terminal; tmux
+ * without `focus-events on`) — there "minimized" and "watching" look
+ * identical, so err on ringing: a redundant ping beats a missed finish.
  */
 export function shouldNotify(
   focus: FocusState,
   opts: { treeId: string; attachedTreeId: string | null },
 ): boolean {
   if (focus === "blurred") return true;
-  return opts.attachedTreeId !== null && opts.attachedTreeId !== opts.treeId;
+  const watchingIt = opts.attachedTreeId === opts.treeId;
+  if (focus === "focused") return opts.attachedTreeId !== null && !watchingIt;
+  return !watchingIt;
 }
 
 /** OS-level toast: fire-and-forget, silent when the notifier is missing. */
@@ -95,7 +99,7 @@ export function systemNotify(title: string, body: string): void {
     let proc;
     if (process.platform === "darwin") {
       // JSON escaping (\" and \\) is valid AppleScript string escaping too.
-      const script = `display notification ${JSON.stringify(body)} with title ${JSON.stringify(title)}`;
+      const script = `display notification ${JSON.stringify(body)} with title ${JSON.stringify(title)} sound name "Glass"`;
       proc = spawn("osascript", ["-e", script], { stdio: "ignore", detached: true });
     } else if (process.platform === "linux") {
       proc = spawn("notify-send", ["--", title, body], { stdio: "ignore", detached: true });

--- a/src/client/notify.ts
+++ b/src/client/notify.ts
@@ -1,0 +1,110 @@
+/**
+ * Attention notifications: tell the user an agent finished, needs input, or
+ * crashed — but only when they could have missed it.
+ *
+ * Delivery (config `notify`, default "terminal"):
+ *  - "bell":     BEL only. Universal transport; tmux turns it into a window
+ *                flag (monitor-bell), macOS Terminal badges the Dock.
+ *  - "terminal": desktop toast via OSC escape codes — kitty speaks OSC 99,
+ *                iTerm2/WezTerm/Ghostty/foot/Warp speak OSC 9 — wrapped for
+ *                tmux passthrough (needs `allow-passthrough on`, tmux ≥ 3.3).
+ *                Terminals with no known OSC support fall back to BEL.
+ *  - "system":   spawn the OS notifier (osascript / notify-send), which works
+ *                in any terminal but not over SSH.
+ *  - "off":      nothing.
+ *
+ * Suppression: the client tracks terminal focus via CSI ?1004 focus
+ * reporting. A blurred terminal always notifies; a focused (or unknown-focus)
+ * one notifies only when the finished tree is hidden behind a different
+ * attached pi — forest/tree views already surface status changes themselves
+ * (teal dot, crash toast).
+ */
+import { spawn } from "node:child_process";
+
+export type NotifyMode = "off" | "bell" | "terminal" | "system";
+export type FocusState = "unknown" | "focused" | "blurred";
+
+export const FOCUS_ENABLE = "\x1b[?1004h";
+export const FOCUS_DISABLE = "\x1b[?1004l";
+export const FOCUS_IN = "\x1b[I";
+export const FOCUS_OUT = "\x1b[O";
+export const BELL = "\x07";
+
+export type OscBackend = "kitty" | "osc9" | "none";
+
+/** Which toast escape dialect the hosting terminal understands, if any. */
+export function detectOscBackend(env: NodeJS.ProcessEnv = process.env): OscBackend {
+  if (env.KITTY_WINDOW_ID || (env.TERM ?? "").includes("kitty")) return "kitty";
+  if (/iTerm|WezTerm|ghostty|WarpTerminal/i.test(env.TERM_PROGRAM ?? "")) return "osc9";
+  if (/wezterm|ghostty|foot/i.test(env.TERM ?? "")) return "osc9";
+  return "none";
+}
+
+/** OSC payload text: strip C0/C1 controls so it cannot terminate the sequence. */
+export function sanitizeOscText(text: string): string {
+  return text.replace(/[\x00-\x1f\x7f\u0080-\u009f]/g, " ");
+}
+
+/**
+ * tmux swallows OSC it doesn't understand; a DCS `tmux;` wrapper (with every
+ * ESC doubled) passes it to the outer terminal when `allow-passthrough` is on.
+ */
+export function wrapTmuxPassthrough(seq: string): string {
+  return "\x1bPtmux;" + seq.replaceAll("\x1b", "\x1b\x1b") + "\x1b\\";
+}
+
+/** The toast escape sequence for this terminal, or null if it has none. */
+export function buildToastSeq(
+  title: string,
+  body: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const t = sanitizeOscText(title);
+  const b = sanitizeOscText(body);
+  let seq: string | null = null;
+  switch (detectOscBackend(env)) {
+    case "kitty":
+      seq = `\x1b]99;i=1:d=0;${t}\x1b\\\x1b]99;i=1:p=body;${b}\x1b\\`;
+      break;
+    case "osc9":
+      // OSC 9 carries a single line — no separate title field.
+      seq = `\x1b]9;${t}: ${b}\x1b\\`;
+      break;
+    case "none":
+      return null;
+  }
+  return env.TMUX ? wrapTmuxPassthrough(seq) : seq;
+}
+
+/**
+ * Notify only when the user could have missed the event: terminal blurred,
+ * or a *different* agent's pi is covering the screen. In forest/tree views
+ * the status change is already visible in the UI.
+ */
+export function shouldNotify(
+  focus: FocusState,
+  opts: { treeId: string; attachedTreeId: string | null },
+): boolean {
+  if (focus === "blurred") return true;
+  return opts.attachedTreeId !== null && opts.attachedTreeId !== opts.treeId;
+}
+
+/** OS-level toast: fire-and-forget, silent when the notifier is missing. */
+export function systemNotify(title: string, body: string): void {
+  try {
+    let proc;
+    if (process.platform === "darwin") {
+      // JSON escaping (\" and \\) is valid AppleScript string escaping too.
+      const script = `display notification ${JSON.stringify(body)} with title ${JSON.stringify(title)}`;
+      proc = spawn("osascript", ["-e", script], { stdio: "ignore", detached: true });
+    } else if (process.platform === "linux") {
+      proc = spawn("notify-send", ["--", title, body], { stdio: "ignore", detached: true });
+    } else {
+      return;
+    }
+    proc.on("error", () => {});
+    proc.unref();
+  } catch {
+    // no notifier on this box — the status dot still tells the story
+  }
+}

--- a/src/client/notify.ts
+++ b/src/client/notify.ts
@@ -95,22 +95,47 @@ export function shouldNotify(
   return !watchingIt;
 }
 
-/** OS-level toast: fire-and-forget, silent when the notifier is missing. */
-export function systemNotify(title: string, body: string): void {
+/** Fire-and-forget process spawn; never throws, never blocks, never logs. */
+function spawnQuiet(cmd: string, args: string[]): void {
   try {
-    let proc;
-    if (process.platform === "darwin") {
-      // JSON escaping (\" and \\) is valid AppleScript string escaping too.
-      const script = `display notification ${JSON.stringify(body)} with title ${JSON.stringify(title)} sound name "Glass"`;
-      proc = spawn("osascript", ["-e", script], { stdio: "ignore", detached: true });
-    } else if (process.platform === "linux") {
-      proc = spawn("notify-send", ["--", title, body], { stdio: "ignore", detached: true });
-    } else {
-      return;
-    }
+    const proc = spawn(cmd, args, { stdio: "ignore", detached: true });
     proc.on("error", () => {});
     proc.unref();
   } catch {
-    // no notifier on this box — the status dot still tells the story
+    // tool missing on this box — the status dot still tells the story
   }
+}
+
+/**
+ * OS-level toast: `mute` skips the notifier's own sound (a custom
+ * `notifySound` is already playing).
+ */
+export function systemNotify(title: string, body: string, opts?: { mute?: boolean }): void {
+  if (process.platform === "darwin") {
+    // JSON escaping (\" and \\) is valid AppleScript string escaping too.
+    const sound = opts?.mute ? "" : ' sound name "Glass"';
+    const script = `display notification ${JSON.stringify(body)} with title ${JSON.stringify(title)}${sound}`;
+    spawnQuiet("osascript", ["-e", script]);
+  } else if (process.platform === "linux") {
+    spawnQuiet("notify-send", ["--", title, body]);
+  }
+}
+
+/**
+ * A `notifySound` spec → playable file path. A bare macOS system sound name
+ * ("Submarine") resolves under /System/Library/Sounds; anything with a slash
+ * or extension is taken as a literal path.
+ */
+export function resolveSoundPath(spec: string, platform: NodeJS.Platform = process.platform): string {
+  if (platform === "darwin" && !spec.includes("/") && !spec.includes(".")) {
+    return `/System/Library/Sounds/${spec}.aiff`;
+  }
+  return spec;
+}
+
+/** Play the configured sound file (afplay / paplay), fire-and-forget. */
+export function playSound(spec: string): void {
+  const file = resolveSoundPath(spec);
+  if (process.platform === "darwin") spawnQuiet("afplay", [file]);
+  else if (process.platform === "linux") spawnQuiet("paplay", [file]);
 }

--- a/src/client/notify.ts
+++ b/src/client/notify.ts
@@ -5,10 +5,12 @@
  * Delivery (config `notify`, default "terminal"):
  *  - "bell":     BEL only. Universal transport; tmux turns it into a window
  *                flag (monitor-bell), macOS Terminal badges the Dock.
- *  - "terminal": desktop toast via OSC escape codes — kitty speaks OSC 99,
- *                iTerm2/WezTerm/Ghostty/foot/Warp speak OSC 9 — wrapped for
- *                tmux passthrough (needs `allow-passthrough on`, tmux ≥ 3.3).
- *                Terminals with no known OSC support fall back to BEL.
+ *  - "terminal": BEL plus a desktop toast via OSC escape codes — kitty
+ *                speaks OSC 99, iTerm2/WezTerm/Ghostty/foot/Warp speak
+ *                OSC 9 — wrapped for tmux passthrough (needs
+ *                `allow-passthrough on`, tmux ≥ 3.3). The BEL rides along
+ *                because a toast can be swallowed silently (alert filtering,
+ *                OS notification permission, Focus mode).
  *  - "system":   spawn the OS notifier (osascript / notify-send), which works
  *                in any terminal but not over SSH.
  *  - "off":      nothing.

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -15,6 +15,16 @@ export interface PinesConfig {
   /** Boot splash animation: "off" disables it (env PINES_BOOT=off also works). */
   boot?: "on" | "off";
   /**
+   * Attention notifications when an agent finishes, needs input, or crashes
+   * while you aren't watching it (default "terminal"):
+   * - "terminal": desktop toast via OSC escapes (kitty/iTerm2/WezTerm/Ghostty/
+   *   foot/Warp; tmux needs `allow-passthrough on`), BEL elsewhere.
+   * - "bell": BEL only (tmux window flag, macOS Terminal badge).
+   * - "system": spawn the OS notifier (osascript / notify-send).
+   * - "off": silence.
+   */
+  notify?: "off" | "bell" | "terminal" | "system";
+  /**
    * Embedding model for semantic layout / similarity. Must produce vectors of
    * one consistent dimension; "Xenova/bge-small-en-v1.5" is a known-good 384-d
    * quality upgrade. Changing this triggers a full re-embed on next start.

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -17,8 +17,8 @@ export interface PinesConfig {
   /**
    * Attention notifications when an agent finishes, needs input, or crashes
    * while you aren't watching it (default "terminal"):
-   * - "terminal": desktop toast via OSC escapes (kitty/iTerm2/WezTerm/Ghostty/
-   *   foot/Warp; tmux needs `allow-passthrough on`), BEL elsewhere.
+   * - "terminal": BEL plus a desktop toast via OSC escapes (kitty/iTerm2/
+   *   WezTerm/Ghostty/foot/Warp; tmux needs `allow-passthrough on`).
    * - "bell": BEL only (tmux window flag, macOS Terminal badge).
    * - "system": spawn the OS notifier (osascript / notify-send).
    * - "off": silence.

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -25,10 +25,11 @@ export interface PinesConfig {
    */
   notify?: "off" | "bell" | "terminal" | "system";
   /**
-   * Custom notification sound, replacing the BEL (or the system notifier's
-   * default sound): a macOS system sound name ("Submarine", "Ping", "Hero",
-   * … — see /System/Library/Sounds) or a path to an audio file. Played via
-   * afplay (macOS) / paplay (Linux).
+   * Notification sound, replacing the BEL (or the system notifier's default
+   * sound): a macOS system sound name ("Submarine", "Ping", "Hero", … — see
+   * /System/Library/Sounds) or a path to an audio file. Played via afplay
+   * (macOS) / paplay (Linux). Default: "Hero" on macOS, unset (BEL)
+   * elsewhere; "" opts back into the plain BEL.
    */
   notifySound?: string;
   /**

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -25,6 +25,13 @@ export interface PinesConfig {
    */
   notify?: "off" | "bell" | "terminal" | "system";
   /**
+   * Custom notification sound, replacing the BEL (or the system notifier's
+   * default sound): a macOS system sound name ("Submarine", "Ping", "Hero",
+   * … — see /System/Library/Sounds) or a path to an audio file. Played via
+   * afplay (macOS) / paplay (Linux).
+   */
+  notifySound?: string;
+  /**
    * Embedding model for semantic layout / similarity. Must produce vectors of
    * one consistent dimension; "Xenova/bge-small-en-v1.5" is a known-good 384-d
    * quality upgrade. Changing this triggers a full re-embed on next start.

--- a/test/notify-flow.test.ts
+++ b/test/notify-flow.test.ts
@@ -6,7 +6,7 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,6 +33,9 @@ async function waitFor(fn: () => boolean, timeoutMs = 8000, what = "condition"):
 beforeAll(async () => {
   home = mkdtempSync(join(tmpdir(), "pines-notify-"));
   mkdirSync(join(home, "sessions"), { recursive: true });
+  // Pin the audible signal to BEL: on macOS the default notifySound ("Hero")
+  // replaces the BEL with an afplay spawn this test cannot observe.
+  writeFileSync(join(home, "config.json"), JSON.stringify({ notifySound: "" }));
   chmodSync(FAKE_PI, 0o755);
   env = {
     ...(process.env as Record<string, string>),

--- a/test/notify-flow.test.ts
+++ b/test/notify-flow.test.ts
@@ -1,0 +1,99 @@
+/**
+ * End-to-end attention notification: an agent that settles in the background
+ * rings the client's terminal (BEL on an OSC-less xterm), including when the
+ * terminal never reports focus — "unknown" must err on ringing, not silence
+ * (the Apple Terminal / tmux-without-focus-events case).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import pty from "node-pty";
+import { ensureNodePtyReady } from "../src/daemon/pty-compat.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, "..");
+const FAKE_PI = join(HERE, "fixtures", "fake-pi.mjs");
+
+let home: string;
+let daemon: ChildProcess;
+let env: Record<string, string>;
+
+async function waitFor(fn: () => boolean, timeoutMs = 8000, what = "condition"): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fn()) return;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  }
+  throw new Error(`timeout waiting for ${what}`);
+}
+
+beforeAll(async () => {
+  home = mkdtempSync(join(tmpdir(), "pines-notify-"));
+  mkdirSync(join(home, "sessions"), { recursive: true });
+  chmodSync(FAKE_PI, 0o755);
+  env = {
+    ...(process.env as Record<string, string>),
+    PINES_HOME: home,
+    PINES_PI_BIN: FAKE_PI,
+    PINES_PI_SESSIONS: join(home, "sessions"),
+    PINES_BOOT: "off",
+    FAKE_PI_EXT: "1", // fake pi reports agent_start → agent_settled
+    FAKE_PI_SETTLE_MS: "1500",
+  };
+  daemon = spawn(process.execPath, [join(ROOT, "dist", "cli.js"), "server"], {
+    env,
+    stdio: "ignore",
+  });
+  await waitFor(() => {
+    try {
+      process.kill(daemon.pid!, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }, 5000, "daemon");
+  await new Promise((resolve) => setTimeout(resolve, 300));
+});
+
+afterAll(() => {
+  daemon?.kill("SIGKILL");
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("attention notification flow", () => {
+  it("rings on settle in forest view even when the terminal never reports focus", async () => {
+    ensureNodePtyReady();
+    const app = pty.spawn(process.execPath, [join(ROOT, "dist", "cli.js")], {
+      name: "xterm-256color", // no known OSC dialect → BEL path
+      cols: 100,
+      rows: 30,
+      cwd: home,
+      env,
+    });
+    let output = "";
+    app.onData((data) => {
+      output += data;
+    });
+
+    await waitFor(() => output.includes("forest"), 5000, "forest");
+    // Focus reporting is requested even if this terminal never answers.
+    expect(output).toContain("\x1b[?1004h");
+    expect(output).not.toContain("\x07");
+
+    // A background agent (running → settled) must ring the watching client.
+    execFileSync(
+      process.execPath,
+      [join(ROOT, "dist", "cli.js"), "spawn", "--cwd", home, "--name", "probe"],
+      { env },
+    );
+    const mark = output.length;
+    await waitFor(() => output.slice(mark).includes("\x07"), 8000, "BEL after settle");
+
+    const exited = new Promise<void>((resolve) => app.onExit(() => resolve()));
+    app.write("q");
+    await exited;
+  });
+});

--- a/test/notify.test.ts
+++ b/test/notify.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildToastSeq,
   detectOscBackend,
+  resolveSoundPath,
   sanitizeOscText,
   shouldNotify,
   wrapTmuxPassthrough,
@@ -76,6 +77,20 @@ describe("buildToastSeq", () => {
     // Exactly one OSC introducer (ours) and one terminator (ours, at the end).
     expect(seq!.match(/\x1b/g)).toHaveLength(2);
     expect(seq!.endsWith("\x1b\\")).toBe(true);
+  });
+});
+
+describe("resolveSoundPath", () => {
+  it("resolves a bare name to a macOS system sound", () => {
+    expect(resolveSoundPath("Submarine", "darwin")).toBe(
+      "/System/Library/Sounds/Submarine.aiff",
+    );
+  });
+
+  it("keeps explicit paths and extensions as given", () => {
+    expect(resolveSoundPath("/tmp/ding.mp3", "darwin")).toBe("/tmp/ding.mp3");
+    expect(resolveSoundPath("ding.wav", "darwin")).toBe("ding.wav");
+    expect(resolveSoundPath("Submarine", "linux")).toBe("Submarine");
   });
 });
 

--- a/test/notify.test.ts
+++ b/test/notify.test.ts
@@ -87,14 +87,20 @@ describe("shouldNotify", () => {
     expect(shouldNotify("blurred", { ...tree, attachedTreeId: "t1" })).toBe(true);
   });
 
-  it("stays quiet when the user is watching the forest or that tree's pi", () => {
+  it("stays quiet when the user is provably watching (known-focused)", () => {
     expect(shouldNotify("focused", { ...tree, attachedTreeId: null })).toBe(false);
     expect(shouldNotify("focused", { ...tree, attachedTreeId: "t1" })).toBe(false);
-    expect(shouldNotify("unknown", { ...tree, attachedTreeId: null })).toBe(false);
   });
 
   it("notifies when a different agent's pi covers the screen", () => {
     expect(shouldNotify("focused", { ...tree, attachedTreeId: "t2" })).toBe(true);
     expect(shouldNotify("unknown", { ...tree, attachedTreeId: "t2" })).toBe(true);
+  });
+
+  it("errs on ringing when the terminal never reports focus", () => {
+    // Apple Terminal / tmux without focus-events: "minimized" and "watching"
+    // are indistinguishable — a missed finish costs more than a spare ping.
+    expect(shouldNotify("unknown", { ...tree, attachedTreeId: null })).toBe(true);
+    expect(shouldNotify("unknown", { ...tree, attachedTreeId: "t1" })).toBe(false);
   });
 });

--- a/test/notify.test.ts
+++ b/test/notify.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildToastSeq,
+  detectOscBackend,
+  sanitizeOscText,
+  shouldNotify,
+  wrapTmuxPassthrough,
+} from "../src/client/notify.js";
+
+describe("detectOscBackend", () => {
+  it("recognizes kitty via KITTY_WINDOW_ID or TERM", () => {
+    expect(detectOscBackend({ KITTY_WINDOW_ID: "1" })).toBe("kitty");
+    expect(detectOscBackend({ TERM: "xterm-kitty" })).toBe("kitty");
+  });
+
+  it("recognizes OSC 9 terminals via TERM_PROGRAM or TERM", () => {
+    expect(detectOscBackend({ TERM_PROGRAM: "iTerm.app" })).toBe("osc9");
+    expect(detectOscBackend({ TERM_PROGRAM: "WezTerm" })).toBe("osc9");
+    expect(detectOscBackend({ TERM_PROGRAM: "ghostty" })).toBe("osc9");
+    expect(detectOscBackend({ TERM_PROGRAM: "WarpTerminal" })).toBe("osc9");
+    expect(detectOscBackend({ TERM: "foot" })).toBe("osc9");
+  });
+
+  it("returns none for unknown terminals", () => {
+    expect(detectOscBackend({})).toBe("none");
+    expect(detectOscBackend({ TERM: "xterm-256color" })).toBe("none");
+    expect(detectOscBackend({ TERM_PROGRAM: "Apple_Terminal" })).toBe("none");
+  });
+});
+
+describe("sanitizeOscText", () => {
+  it("strips control characters that could terminate the sequence", () => {
+    expect(sanitizeOscText("a\x1b]9;evil\x07b\x9cc")).toBe("a ]9;evil b c");
+  });
+
+  it("keeps ordinary text, dashes, and unicode", () => {
+    expect(sanitizeOscText("fix-auth · done ✓")).toBe("fix-auth · done ✓");
+  });
+});
+
+describe("wrapTmuxPassthrough", () => {
+  it("wraps in DCS tmux; with every ESC doubled", () => {
+    expect(wrapTmuxPassthrough("\x1b]9;hi\x1b\\")).toBe(
+      "\x1bPtmux;\x1b\x1b]9;hi\x1b\x1b\\\x1b\\",
+    );
+  });
+});
+
+describe("buildToastSeq", () => {
+  it("emits OSC 9 with title folded into the body line", () => {
+    expect(buildToastSeq("pines", "auth finished", { TERM_PROGRAM: "iTerm.app" })).toBe(
+      "\x1b]9;pines: auth finished\x1b\\",
+    );
+  });
+
+  it("emits two-part OSC 99 for kitty", () => {
+    expect(buildToastSeq("pines", "auth finished", { KITTY_WINDOW_ID: "1" })).toBe(
+      "\x1b]99;i=1:d=0;pines\x1b\\\x1b]99;i=1:p=body;auth finished\x1b\\",
+    );
+  });
+
+  it("returns null when the terminal has no known dialect", () => {
+    expect(buildToastSeq("pines", "auth finished", { TERM: "xterm-256color" })).toBeNull();
+  });
+
+  it("wraps for tmux passthrough when $TMUX is set", () => {
+    const seq = buildToastSeq("pines", "hi", {
+      TERM_PROGRAM: "WezTerm",
+      TMUX: "/tmp/tmux-1000/default,42,0",
+    });
+    expect(seq).toBe("\x1bPtmux;\x1b\x1b]9;pines: hi\x1b\x1b\\\x1b\\");
+  });
+
+  it("cannot be escaped by hostile payload text", () => {
+    const seq = buildToastSeq("pines", "x\x1b\\;rm -rf\x07", { TERM_PROGRAM: "iTerm.app" });
+    // Exactly one OSC introducer (ours) and one terminator (ours, at the end).
+    expect(seq!.match(/\x1b/g)).toHaveLength(2);
+    expect(seq!.endsWith("\x1b\\")).toBe(true);
+  });
+});
+
+describe("shouldNotify", () => {
+  const tree = { treeId: "t1" };
+
+  it("always notifies when the terminal is blurred", () => {
+    expect(shouldNotify("blurred", { ...tree, attachedTreeId: null })).toBe(true);
+    expect(shouldNotify("blurred", { ...tree, attachedTreeId: "t1" })).toBe(true);
+  });
+
+  it("stays quiet when the user is watching the forest or that tree's pi", () => {
+    expect(shouldNotify("focused", { ...tree, attachedTreeId: null })).toBe(false);
+    expect(shouldNotify("focused", { ...tree, attachedTreeId: "t1" })).toBe(false);
+    expect(shouldNotify("unknown", { ...tree, attachedTreeId: null })).toBe(false);
+  });
+
+  it("notifies when a different agent's pi covers the screen", () => {
+    expect(shouldNotify("focused", { ...tree, attachedTreeId: "t2" })).toBe(true);
+    expect(shouldNotify("unknown", { ...tree, attachedTreeId: "t2" })).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Pines had no way to tell you an agent was done unless you were staring at the forest. This adds attention notifications: when an agent settles (finished — waiting for you), completes, or crashes, the client rings the terminal — unless you're provably already looking at it.

The design follows what herdr and opencode converged on for the same problem.

## How

**New `src/client/notify.ts`** (pure, unit-tested):
- **Toast via OSC escapes**: backend sniffed from `TERM_PROGRAM` / `TERM` / `KITTY_WINDOW_ID` — kitty gets a two-part OSC 99, iTerm2/WezTerm/Ghostty/foot/Warp get OSC 9. Inside tmux the sequence is wrapped in `DCS tmux;` passthrough (ESC doubled; needs `allow-passthrough on`, tmux ≥ 3.3). Payload text is sanitized (C0/C1 stripped) so a hostile tree name can't break out of the sequence.
- **Sound**: `notifySound` config — a macOS system sound name (resolved under `/System/Library/Sounds`) or an audio file path, played via `afplay` / `paplay`. **Defaults to `Hero` on macOS**, decoupling the ding from terminal bell settings; `""` opts back into the plain BEL.
- **BEL rides along with every toast** when no sound is configured — a toast can be swallowed with no trace (iTerm2 alert filtering, missing macOS notification permission, Focus mode), so there is always an audible/terminal-visible signal; terminals without a known OSC dialect get the BEL alone. Pairs with tmux `monitor-bell` and the macOS Terminal badge.
- **System mode**: spawns `osascript` (macOS, audible) / `notify-send` (Linux), fire-and-forget, silent when missing.
- **Suppression policy** (`shouldNotify`): only a *provably* focused terminal showing the forest/tree views (or that agent's own pi) stays quiet. Blurred rings; a focused terminal covered by a *different* agent's pi rings; and **unknown focus rings too** — a terminal that never reports focus (Apple Terminal; tmux without `focus-events on`) can't distinguish "minimized" from "watching", and a redundant ping beats a missed finish.

**Client wiring in `src/client/app.ts`**:
- Enables CSI `?1004` focus reporting at startup (re-asserted after detaching from a pi, disabled on cleanup); `\x1b[I` / `\x1b[O` are intercepted for tri-state focus tracking and still forwarded to an attached pi.
- Hooks the existing `forest_update` transition detection: `running → waiting | completed | crashed` fires `notifyAttention`.
- 30s per-tree cooldown guards against status flapping from the PTY-quiet heuristic used for extension-less agents.

**Config** (`~/.pines/config.json`): `"notify": "off" | "bell" | "terminal" | "system"` (default `"terminal"`) and `"notifySound"` (default `"Hero"` on macOS). Documented in `docs/GUIDE.md`.

**Release**: bumps `package.json` to 0.1.8 — merging publishes to npm via the version-bump release workflow.

## Testing

- 18 unit tests in `test/notify.test.ts`: backend detection, OSC 9/99 sequence shape, tmux wrapping, payload-injection resistance, sound-path resolution, and the suppression policy.
- End-to-end PTY test in `test/notify-flow.test.ts`: a fake pi settles in the background and the client must emit BEL — specifically on a terminal that never reports focus, the case that was silently broken before the policy fix.
- Full suite: 33 files / 187 tests pass; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jzshiTHkW4HfsTrPWjmGw