### PR TITLE
v0.1.9: graph paper anchored to the world — the grid pans with the trees

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edeng23/pines",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Tree-first orchestration TUI for pi coding agents. pi + trees = pines.",
   "license": "Apache-2.0",
   "author": "Eden Gaon",

--- a/src/client/forest/style.ts
+++ b/src/client/forest/style.ts
@@ -11,7 +11,7 @@
  * choice: they come from `status.ts` so a yellow spinner always means
  * "working".
  */
-import type { TreeSummary } from "../../shared/types.js";
+import type { Camera, TreeSummary } from "../../shared/types.js";
 import type { Canvas } from "./canvas.js";
 import type { Viewport } from "./camera.js";
 
@@ -73,6 +73,12 @@ export interface DrawCtx extends PlacedTree {
 
 export interface UnderlayCtx {
   vp: Viewport;
+  /**
+   * The camera, so a backdrop can pin itself to the world: graph paper that
+   * ignores the pan reads as a smudge on the window, not ground under the
+   * trees.
+   */
+  camera: Camera;
   visible: PlacedTree[];
   /**
    * Median distance in cells between a tree and its nearest neighbor. A

--- a/src/client/forest/styles.ts
+++ b/src/client/forest/styles.ts
@@ -5,6 +5,7 @@
  */
 import type { TreeSummary } from "../../shared/types.js";
 import type { Canvas } from "./canvas.js";
+import { worldToCell } from "./camera.js";
 import { FAINT, GRID, MUTED } from "../theme.js";
 import { statusGlyph, statusSgr } from "./status.js";
 import { treeTitle } from "./sidebar.js";
@@ -284,10 +285,18 @@ export const canopy: ForestStyle = {
     // cell's top-left corner and is small enough to vanish. A centered `·`
     // reads as a ruled point. Nothing else in this look draws braille, and
     // the underlay runs before edges and trees, so they still paint over it.
+    //
+    // The ruling keeps its density in cells (world-unit squares would flood
+    // at low zoom and vanish at high), but its phase is pinned to the world
+    // origin: panning slides the paper with the trees, so it reads as ground
+    // they stand on rather than a smudge on the glass.
     const step = ctx.spacing < 8 ? 8 : 6;
-    for (let y = 0; y < ctx.vp.height; y += step / 2) {
-      for (let x = 0; x < ctx.vp.width; x += step) {
-        canvas.set(x, Math.round(y), "·", GRID);
+    const yStep = step / 2;
+    const origin = worldToCell(ctx.camera, ctx.vp, 0, 0);
+    const phase = (v: number, s: number) => ((Math.round(v) % s) + s) % s;
+    for (let y = phase(origin.y, yStep); y < ctx.vp.height; y += yStep) {
+      for (let x = phase(origin.x, step); x < ctx.vp.width; x += step) {
+        canvas.set(x, y, "·", GRID);
       }
     }
   },

--- a/src/client/forest/view.ts
+++ b/src/client/forest/view.ts
@@ -78,7 +78,7 @@ export function renderForest(canvas: Canvas, input: ForestRenderInput): Map<numb
 
   // Backdrop (grids, contour rings), then lineage edges: both live under
   // every marker.
-  style.underlay?.(canvas, { vp, visible, spacing: medianSpacing(visible) });
+  style.underlay?.(canvas, { vp, camera, visible, spacing: medianSpacing(visible) });
 
   const byPath = new Map<string, TreeSummary>();
   for (const t of trees) byPath.set(t.sessionPath, t);

--- a/test/forest-styles.test.ts
+++ b/test/forest-styles.test.ts
@@ -124,6 +124,32 @@ describe("canopy", () => {
     }
     expect(owners).toContain("neighbor");
   });
+
+  it("pans the graph paper with the forest, not the window", () => {
+    // The grid is anchored to the world: dragging the camera slides the
+    // dots along with the trees instead of leaving them pinned on screen.
+    const vp = { width: 80, height: 24 };
+    const solo = [tree({ treeId: "lone" })];
+    const dotCols = (cx: number): number[] => {
+      const canvas = new Canvas(vp.width, vp.height);
+      renderForest(canvas, {
+        trees: solo,
+        camera: { cx, cy: 0, zoom: 2 },
+        vp,
+        selectedId: null,
+        spinnerFrame: 0,
+      });
+      const row = canvas.render()[0]!.replace(/\x1b\[[0-9;]*m/g, "");
+      return [...row].flatMap((ch, x) => (ch === "·" ? [x] : []));
+    };
+    const before = dotCols(0);
+    // Pan the camera 3 cells' worth left: everything on screen moves 3 right.
+    const after = dotCols(-1.5);
+    expect(before.length).toBeGreaterThan(0);
+    const shifted = before.map((x) => x + 3).filter((x) => x < vp.width);
+    expect(after).toEqual(expect.arrayContaining(shifted));
+    expect(after).not.toEqual(before);
+  });
 });
 
 describe("crowding", () => {


### PR DESCRIPTION
## Summary

The canopy underlay drew its middot graph-paper ruling in pure screen coordinates, so dragging the camera moved the forest while the background dots stayed pinned to the window. The grid now derives its phase from where the world origin lands on screen, so panning slides the paper together with the trees and it reads as ground they stand on.

- Thread the camera into the style `underlay` context (`view.ts`, `style.ts`)
- Anchor the canopy grid's phase to the world origin (`styles.ts`); density deliberately stays fixed in cells — a world-unit grid would flood at low zoom and vanish at high, so zooming re-rules the paper while panning moves it
- Regression test: render at two camera positions and assert the dot columns shift by exactly the pan distance
- Bump version to 0.1.9 so the merge cuts a release

## Testing

- `pnpm typecheck` clean
- All 20 `test/forest-styles.test.ts` tests pass, including the new one (remaining suite failures are pre-existing daemon/pty environment issues, identical on the untouched tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CVWpn9xkm6FWetBHUoV1u